### PR TITLE
Add WordToTime to Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [UFreeTools](https://www.ufreetools.com/) - Your Online Free Toolkit.
 - [Play Go Hub](https://playgohub.com/) - Professional Gaming Tools & Guides
 - [rtcd.io](https://rtcd.io/) - Free online toolkit for audio editing, image processing, development and more.
+- [WordToTime](https://wordtotime.org) — Convert word/character counts or full text into estimated speaking, reading or narration time. Supports multiple languages and in-browser privacy-friendly processing.
 
 ### White Board
 


### PR DESCRIPTION
This pull request adds **WordToTime (https://wordtotime.org)** to the Tools collection.

**Why this website is helpful**  
WordToTime is a browser-based tool that allows you to convert word counts, character counts, and full text scripts into estimated speaking, reading, or narration time. It supports multiple languages, narration styles (speech, voice-over, podcast, video), and in-browser processing without uploading text, making it privacy-friendly.

**Key features**  
- Paste your script or input word/character/page count → get estimated duration (HH:MM:SS)  
- Multiple modes: speech, reading, video narration, podcast, audiobook  
- Adjustable pace settings and pause modelling for realistic timing  
- Supports both word-based and character-based languages  

Thanks for maintaining this great list of websites.