### PR TITLE
Add Speaking Time Calculator Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [giga.tools](https://giga.tools/) - Collection of useful in-browser tools for developers, designers, and power-users ranging from video editing, image editing, to text editing, and more.
 - [WordToTime](https://wordtotime.org) — Convert word/character counts or full text into estimated speaking, reading or narration time. Supports multiple languages and in-browser privacy-friendly processing.
 - [VolumeShaderBM](https://volumeshaderbm.org) — Browser-based real-time GPU volume shader benchmark with WebGPU/WebGL performance comparison.
+- [Speaking Time Calculator](https://speakingtimecalculator.org) – A free online tool to estimate speaking or presentation time from text using adjustable speaking speed (WPM).
 
 ### White Board
 


### PR DESCRIPTION
### Add Speaking Time Calculator

This PR adds a free and simple online tool that estimates speaking or presentation duration based on text length and adjustable speaking pace (WPM).

It’s a lightweight, browser-based utility that can be useful for presentations, talks, demos, and content planning.
