### PR TITLE
Add DomainBFF to tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Each website is included only once. Some websites can fall into multiple categor
 ## Tools
 
 - [5000Best Tools](https://5000best.com/tools/) - 5000 tools.
+- [DomainBFF](https://domainbff.com/) - Suite of domain name research tools with unlimited usage 
 - [10015.io](https://10015.io/) - Free all-in-one toolbox for various tasks.
 - [UnTools](https://untools.co/) - Collection of thinking tools and frameworks.
 - [TimeTravel Memento](https://timetravel.mementoweb.org/) - Find Mementos in Internet Archive, Archive-It, British Library, archive.today, GitHub, and more.


### PR DESCRIPTION
Added DomainBFF to tools. It's a domain research tool platform with 8 tools for domain names including bulk search across 350M+ domains, sales history database, lead finder, and AI name generator.