### PR TITLE
Add NexTool to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [giga.tools](https://giga.tools/) - Collection of useful in-browser tools for developers, designers, and power-users ranging from video editing, image editing, to text editing, and more.
 - [WordToTime](https://wordtotime.org) — Convert word/character counts or full text into estimated speaking, reading or narration time. Supports multiple languages and in-browser privacy-friendly processing.
 - [VolumeShaderBM](https://volumeshaderbm.org) — Browser-based real-time GPU volume shader benchmark with WebGPU/WebGL performance comparison.
+- [NexTool](https://nextool.app/free-tools/) - 228+ free browser-based developer tools including JSON formatter, Base64 encoder, regex tester, color converter, UUID generator, and more. No signup required.
 - [Speaking Time Calculator](https://speakingtimecalculator.org) – A free online tool to estimate speaking or presentation time from text using adjustable speaking speed (WPM).
 
 ### White Board


### PR DESCRIPTION
## What is NexTool?

[NexTool](https://nextool.app/free-tools/) — 228+ free browser-based developer tools including JSON formatter, Base64 encoder, regex tester, color converter, UUID generator, and more. No signup required.

## Why add it?

NexTool fits well in the **Tools** section alongside similar entries like [10015.io](https://10015.io/) and [giga.tools](https://giga.tools/). It provides a comprehensive, free, browser-based toolbox for developers covering encoding/decoding, formatting, generating, converting, and other common tasks — all without requiring signup or installation.

- Website is up and running
- Not a duplicate (searched the README)
- Follows the existing format