### PR TITLE
Add YEIN Maldives to Travel section

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Welcome to My Garden](https://welcometomygarden.org/) - A non-profit network offering free camping spots in private gardens for slow travelers.
 - [Warmshowers](https://www.warmshowers.org/) - A community of bicycle tourists and hosts supporting them during their journeys.
 - [Slowby](https://www.slowby.travel/) - A platform offering highly-curated slow travel trips for a unique travel experience.
+- [YEIN Maldives](https://yein.cn) - Comprehensive Maldives travel guide with an intelligent island selector for 185+ resorts, flight routes, budget tips, and themed travel categories.
 
 ### Globetrotting
 


### PR DESCRIPTION
Hi! I'd like to add [YEIN Maldives](https://yein.cn) to the **Travel** section.

## About

YEIN Maldives is a comprehensive Maldives travel planning resource that helps travelers:

- **Compare 185+ resorts** using an intelligent island selector with filters for budget, travel style, and preferences
- **Find flight routes** — direct and connecting flights from major cities worldwide
- **Plan budgets** — detailed cost breakdowns for different resort tiers
- **Browse themed categories** — curated resort collections for honeymoons, family trips, diving, and more

Available in Chinese, English, and Traditional Chinese.

I believe this fits well alongside other travel planning tools like Roadtrippers, Slowby, and AllTrails in the Travel section. Thank you for maintaining this awesome list!