### PR TITLE
Add VerifySMS under Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1731,6 +1731,10 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Postale](https://postale.io/) ($) - Allows you to create domain email addresses effortlessly in minutes.
 - [Temporary Mail](https://tempmailto.online/) - Secure Temporary Mail Service for Privacy Protection
 
+#### Disposable Phone Numbers
+
+- [VerifySMS](https://verifysms.app/) ($) - Receive SMS verification codes on instant virtual numbers from 200+ countries without sharing your real phone number. iOS app and web, no KYC, pay-as-you-go from $0.10.
+
 
 ### Data Breach
 


### PR DESCRIPTION
Adds **VerifySMS** to the Privacy section as a new "Disposable Phone Numbers" subsection, following the same pattern already used for Disposable Email.

VerifySMS provides instant virtual phone numbers in 200+ countries to receive SMS verification codes without exposing your real number. It targets the same privacy use case as the disposable email tools already on this list (BurnerMail, Maildrop, Erine Email, Guerrilla Mail) but for the phone-number side of online sign-ups and 2FA. iOS app and web, no KYC, pay-as-you-go from $0.10.

Disclosure: I'm involved with the project, so I've marked the entry with the ($) paid indicator already used elsewhere on the list (Postale, YAMM). Happy to rephrase, move it under `### Emails` as a sibling, or split off a new top-level Phone Numbers heading instead — whichever fits the list's style best.

Format used: `[VerifySMS](https://verifysms.app/) ($) - Receive SMS verification codes on instant virtual numbers from 200+ countries without sharing your real phone number. iOS app and web, no KYC, pay-as-you-go from $0.10.`