### PR TITLE
Add Remove Audio to Tools / Visual

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [ByClickDownloader](https://www.byclickdownloader.com/) - Backup videos from various sites in HD, MP3, MP4, AVI, and other formats using their software.
 - [Reanimate](https://reanimate.github.io/) - Build declarative animations with SVG and Haskell.
 - [Photopea](https://photopea.com/) - Free online photo editor similar to Photoshop.
+- [Remove Audio (free tool)](https://remove-audio.com) - Strip the audio track from any video right in your browser. Runs locally with FFmpeg.wasm, no uploads, no signup, no watermark.
 
 ### Data Entry
 


### PR DESCRIPTION
Adds Remove Audio to the Tools / Visual section, next to other browser-based image and video utilities like Crossfade.io, EZGIF, and ClipDrop.

Remove Audio is a free, no-signup, no-watermark browser tool that strips the audio track from any video. Processing happens entirely on the user's device via WebAssembly and FFmpeg.wasm, so files never reach a server. It is a small but genuinely useful site of the kind this list collects.