### PR TITLE
Add Free Background Remover to Tools > Visual

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [ByClickDownloader](https://www.byclickdownloader.com/) - Backup videos from various sites in HD, MP3, MP4, AVI, and other formats using their software.
 - [Reanimate](https://reanimate.github.io/) - Build declarative animations with SVG and Haskell.
 - [Photopea](https://photopea.com/) - Free online photo editor similar to Photoshop.
+- [remove image backgrounds online for free](https://free-background-remover.com) - AI background remover that runs entirely in the browser, no upload, no sign-up, no watermark.
 
 ### Data Entry
 


### PR DESCRIPTION
Adds Free Background Remover (https://free-background-remover.com) to Tools > Visual.

The section already lists Remove.bg, Foco Clipping, and Designify, all background removal tools. Free Background Remover sits alongside them with one difference: the AI segmentation model runs locally in the browser, so photos never leave the user's device. No upload, no sign-up, no watermark, no daily limit.