### PR TITLE
Add Hanzilla Jobs to job resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Y Combinator Jobs](https://www.ycombinator.com/jobs) - Discover the best startup jobs curated by Y Combinator.
 - [Coroflot](https://www.coroflot.com/discover) - Job search platform specifically tailored for designers.
 - [Cool Startup Jobs](https://www.coolstartupjobs.com/) - Explore job opportunities in growing startups and give your stock options a chance.
+- [Hanzilla Jobs](https://jobs.hanzilla.co/) - Free daily-updated Canadian student and recent-graduate jobs board for internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more.
 - [Anon Friendly](https://anonfriendly.com/) - Find jobs that respect your desire for anonymity.
 - [Prompt Engineering Jobs](https://prompt-engineering-jobs.com) - Explore engineering job opportunities with Prompt.
 - [KeyValues](https://www.keyvalues.com/) - Find engineering teams that align with your values.


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the job portals directory as a Canada-focused student/recent-grad resource.
- Kept the entry short and tagged it for Canada/student-friendly usage.

## Why
The list asks for underrepresented country/sector portals. Hanzilla Jobs is a free, daily-updated board for Canadian students and recent grads looking for internships, co-ops, new grad, junior, and entry-level roles across multiple fields.

## Checks
- Verified the URL is live: https://jobs.hanzilla.co/
