### PR TITLE
docs: add AIPower.spot to list

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,4 @@
+This work is licensed under Attribution 4.0 International (CC BY 4.0).
+To view a copy of this license, visit <https://creativecommons.org/licenses/by/4.0/>
+
+By accessing and using the Awesome Useful Websites project ("the Project") on GitHub, you agree that the Project is not affiliated with, sponsored by, or endorsed by any of the websites listed. While efforts are made to maintain accurate and up-to-date information, the Project makes no guarantees regarding the accuracy, completeness, or reliability of the content. Changes of the content of linked websites are beyond the Project's control. The Project is provided "as is" without any warranties, express or implied.

--- a/README.md
+++ b/README.md
@@ -1415,7 +1415,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [ExplainPaper](https://www.explainpaper.com/) - Platform where users can upload a research paper, highlight confusing text, and receive an explanation to make research papers easier to read.
 - [Summarize Tech](https://www.summarize.tech/) - AI-powered tool to get a summary of any long YouTube video, such as lectures, live events, or government meetings.
 - [YouTubeTranscript](https://youtubetranscript.com/) - Get a YouTube video transcript and summaries
-
+- [Vibbo AI](https://vibboai.com/) - Quick AI tools to convert any text, image, audio or video. 
 ### Data Science
 
 - [DataTau](https://www.datatau.com/news) - Hackernews but for data

--- a/README.md
+++ b/README.md
@@ -1721,6 +1721,8 @@ Each website is included only once. Some websites can fall into multiple categor
 - [GetNotify](https://www.getnotify.com/) - A free email tracking service that notifies you when the emails you send are read.
 - [MXToolbox](https://mxtoolbox.com/) - Offers free DNS and email tools in a single place for streamlined troubleshooting.
 - [Postale](https://postale.io/) ($) - Allows you to create domain email addresses effortlessly in minutes.
+- [Temporary Mail](https://tempmailto.online/) - Secure Temporary Mail Service for Privacy Protection
+
 
 ### Data Breach
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [UFreeTools](https://www.ufreetools.com/) - Your Online Free Toolkit.
 - [Play Go Hub](https://playgohub.com/) - Professional Gaming Tools & Guides
 - [rtcd.io](https://rtcd.io/) - Free online toolkit for audio editing, image processing, development and more.
+- [giga.tools](https://giga.tools/) - Collection of useful in-browser tools for developers, designers, and power-users ranging from video editing, image editing, to text editing, and more.
 
 ### White Board
 

--- a/README.md
+++ b/README.md
@@ -863,6 +863,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Doodlicons on Notion](https://www.notion.so/Doodlicons-519314a92ed3474093a10e44946bbb72) - Doodle icons for project wireframes on Notion.
 - [Illustration Kit](https://illustrationkit.com/) - Collection of free vector illustrations for personal and commercial projects.
 - [FontAwesome](https://fontawesome.com/) - Internet's icon library and toolkit, widely used by designers, developers, and content creators.
+- [Flat Icon](https://www.flaticon.com/) - Provides a library of free and premium icons. Most icons are free but require attributions and usually only offer PNGs. Premium is usually required for SVGs.
 - [Iconshock](https://www.iconshock.com/freeicons/) - Platform offering icons from various open-source collections, with 100k icons available for free download.
 - [3DIcons](https://3dicons.co/) - Collection of 3D icons available for free commercial and personal use under CC0 license.
 - [Fontello](https://fontello.com/) - Icon fonts generator for creating custom icon fonts.

--- a/README.md
+++ b/README.md
@@ -877,6 +877,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Iconfinder](https://www.iconfinder.com/) ($) - Platform offering icons, illustrations, 3D illustrations, designers, and free icons.
 - [Iconz Design](https://iconz.design/) ($) - Premium 3D library of 223 icons.
 - [HugeIcons.pro](https://hugeicons.pro/) ($) - Platform offering over 25,000 icons in 5 unique styles, organized across 57 popular categories.
+- [Game-Icons.net](https://game-icons.net/) - Provides a collection of free creative commons SVG and PNG icons specifically designed for videogames.
 
 #### Stock Images
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [UFreeTools](https://www.ufreetools.com/) - Your Online Free Toolkit.
 - [Play Go Hub](https://playgohub.com/) - Professional Gaming Tools & Guides
 - [rtcd.io](https://rtcd.io/) - Free online toolkit for audio editing, image processing, development and more.
+- [WordToTime](https://wordtotime.org) — Convert word/character counts or full text into estimated speaking, reading or narration time. Supports multiple languages and in-browser privacy-friendly processing.
 
 ### White Board
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Emoji Combos](https://emojicombos.com/) - Collection of emoji combinations and sequences.
 - [ASCII World](https://www.asciiworld.com/) - Platform featuring ASCII art and tutorials.
 - [Rentry](https://rentry.co/FMHY) - Online collaborative markdown editor.
+- [FontGenerator.design](https://fontgenerator.design/) - Unicode-based text generator for bold, fancy, and other font-like effects.
+- [GlitchText.cool](https://glitchtext.cool/)- Unicode glitch/Zalgo text generator with adjustable distortion.
 
 ### Automating browser
 

--- a/README.md
+++ b/README.md
@@ -1361,7 +1361,6 @@ Each website is included only once. Some websites can fall into multiple categor
 
 ## AI/ML
 
-- [Doublespeak Chat](https://doublespeak.chat/#/handbook) - Empirical, non-academic, and practical guide to LLM hacking.
 - [Fast.ai Course](https://course.fast.ai/) - Online course for deep learning and machine learning.
 - [Papers with Code](https://paperswithcode.com/sota) - Collection of state-of-the-art results for machine learning tasks with associated code.
 - [Delta Academy Maps](https://maps.joindeltaacademy.com/) - Map of mathematics for Machine Learning.
@@ -1371,7 +1370,9 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Globe Engineer Explorer](https://explorer.globe.engineer/) - Applied AI company making products that optimally represent information for human comprehension.
 - [Colah's Blog](https://colah.github.io/) - Blog by Christopher Olah on deep learning and artificial intelligence, featuring detailed explanations, tutorials, and research insights.
 - [TensorFlow Playground](https://playground.tensorflow.org) - An interactive tool for experimenting with neural networks, allowing users to visualize how different configurations affect model training and classification tasks.
-- [Ben's Bites](https://bensbites.com/catalog) - Catalog offering a variety of bite-sized AI resources.
+- [Future Tools](https://www.futuretools.io/) - Platform for finding the exact AI tool for your needs.
+- [AI Tools Arena](https://aitoolsarena.com/) - Platform showcasing various AI tools and resources.
+- [Aiva Valley](https://aivalley.ai/) - The latest source of AI tools and prompts.
 
 ### Robotics
 
@@ -1398,27 +1399,6 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Free Midjourney Prompt](https://www.freemidjourneyprompt.com/) - Offers a wide selection of free Midjourney prompts, allowing users to easily generate images by providing optimized natural language prompts.
 - [Prompt Engineering Guide](https://learnprompting.org/docs/introduction) - Serves as a comprehensive guide to prompt engineering, offering essential principles and techniques for crafting effective prompts for AI models and creative tasks.
 
-### AI tools
-
-- [Future Tools](https://www.futuretools.io/) - Platform for finding the exact AI tool for your needs.
-- [WarpSound AI](https://www.warpsound.ai/) - Create high-quality generative AI music in seconds with just prompts.
-- [AI Tools Arena](https://aitoolsarena.com/) - Platform showcasing various AI tools and resources.
-- [Klavier AI](https://klavier.ai/) - Allows you to do Q&A with ChatGPT on web pages and docs you choose.
-- [Aiva Valley](https://aivalley.ai/) - The latest source of AI tools and prompts.
-- [Bardeen AI](https://www.bardeen.ai/) - Automate manual work and tasks with AI without any code in minutes.
-- [Speechify](https://speechify.com/) - Power through documents, articles, PDFs, email—anything you read—by listening with their leading AI text-to-speech reader.
-- [Humata AI](https://www.humata.ai/) - Upload any PDF or document and get answers from it in seconds.
-- [Syntelly](https://app.syntelly.com/search) - Artificial intelligence for organic and medical chemistry.
-- [Warp.dev - Warp AI](https://www.warp.dev/warp-ai?source=producthunt&ref=producthunt) - AI-powered tool for building APIs without writing code.
-- [Feedback by AI](https://feedbackbyai.com/?ref=producthunt) - Platform utilizing AI for generating actionable feedback on writing.
-- [Seeing the World through Your Eyes](https://world-from-eyes.github.io/) - Reconstruct the world that is reflected through human eyes.
-- [Auxiliary Tools](https://www.auxiliary.tools/) - Platform offering AI experiments and tools for humans.
-- [Hemingway Editor](https://hemingwayapp.com/) - Spellchecker, but for style.
-- [FuturePedia](https://www.futurepedia.io/) - Leading AI resource platform dedicated to empowering professionals across various industries to leverage AI technologies for innovation and growth.
-- [ExplainPaper](https://www.explainpaper.com/) - Platform where users can upload a research paper, highlight confusing text, and receive an explanation to make research papers easier to read.
-- [Summarize Tech](https://www.summarize.tech/) - AI-powered tool to get a summary of any long YouTube video, such as lectures, live events, or government meetings.
-- [YouTubeTranscript](https://youtubetranscript.com/) - Get a YouTube video transcript and summaries
-- [Vibbo AI](https://vibboai.com/) - Quick AI tools to convert any text, image, audio or video. 
 ### Data Science
 
 - [DataTau](https://www.datatau.com/news) - Hackernews but for data
@@ -2145,4 +2125,4 @@ This work is licensed under a [Creative Commons Attribution 4.0 International](h
 
 **How to credit:**
 
-- You must add a link to this [GitHub main page](https://github.com/atakanaltok/awesome-useful-websites) in an `about` or `acknowledgments` section visible to the user.
+- You must add a link to this [GitHub main page](https://github.com/atakanaltok/awesome-useful-websites) in a relevant section visible to the user.

--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Roadmap.sh](https://roadmap.sh/) - Provides roadmaps for various development areas.
 - [WTF Should I Do With My Life](https://www.wtfshouldidowithmylife.com/) - A resource to explore and learn about different occupations.
 - [path-to-polymath.notion](https://path-to-polymathy.notion.site/path-to-polymathy/Path-To-Polymathy-d7586429b7ce4db1889fc539822b9670) - Arrangement of every discipline and field out there, and what specific topics make them up.
+- [80,000 Hours](https://80000hours.org/) - Conducts research into the world's biggest problems, big industry questions, job boards, and general career advice to make a big impact.
 
 ## Startups
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Rentry](https://rentry.co/FMHY) - Online collaborative markdown editor.
 - [FontGenerator.design](https://fontgenerator.design/) - Unicode-based text generator for bold, fancy, and other font-like effects.
 - [GlitchText.cool](https://glitchtext.cool/)- Unicode glitch/Zalgo text generator with adjustable distortion.
+- [Share Text Online With Link](https://share-text.org/) - Share Text Online With Link and QR Code
 
 ### Automating browser
 

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [giga.tools](https://giga.tools/) - Collection of useful in-browser tools for developers, designers, and power-users ranging from video editing, image editing, to text editing, and more.
 - [WordToTime](https://wordtotime.org) — Convert word/character counts or full text into estimated speaking, reading or narration time. Supports multiple languages and in-browser privacy-friendly processing.
 - [VolumeShaderBM](https://volumeshaderbm.org) — Browser-based real-time GPU volume shader benchmark with WebGPU/WebGL performance comparison.
+- [Speaking Time Calculator](https://speakingtimecalculator.org) – A free online tool to estimate speaking or presentation time from text using adjustable speaking speed (WPM).
 
 ### White Board
 

--- a/README.md
+++ b/README.md
@@ -894,6 +894,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Depositphotos](https://depositphotos.com/) - Platform with 232 million files, including royalty-free images, videos, vectors, illustrations, and music.
 - [Skuawk](https://skuawk.com/) - Source of public domain photos for various creative projects.
 - [All-Free-Download](https://all-free-download.com/) - Platform offering graphics art available for free use in personal or commercial projects.
+- [Open Verse](https://openverse.org/) - A search tool to find openly licensed and public domain works across the internet.
 
 #### Wallpapers
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [rtcd.io](https://rtcd.io/) - Free online toolkit for audio editing, image processing, development and more.
 - [giga.tools](https://giga.tools/) - Collection of useful in-browser tools for developers, designers, and power-users ranging from video editing, image editing, to text editing, and more.
 - [WordToTime](https://wordtotime.org) — Convert word/character counts or full text into estimated speaking, reading or narration time. Supports multiple languages and in-browser privacy-friendly processing.
+- [VolumeShaderBM](https://volumeshaderbm.org) — Browser-based real-time GPU volume shader benchmark with WebGPU/WebGL performance comparison.
 
 ### White Board
 

--- a/README.md
+++ b/README.md
@@ -1481,6 +1481,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [CSS Solid](https://www.csssolid.com/) - CSS references, tutorials, and articles.
 - [CSS-Tricks](https://css-tricks.com/) - Web design community powered by Digital Ocean.
 - [CSS Box Shadow Code Snippet](https://onaircode.com/css-box-shadow-code-snippet/) - Code snippet for creating CSS box shadows.
+- [UI Verse](https://uiverse.io/) - A library of open source UI elements that can be copied as HTML/CSS, Tailwind, React, and Figma.
 
 #### JavaScript
 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Time and Date](https://www.timeanddate.com/) - Provides calendars, clocks, and various time-related information.
 - [Time.is](https://time.is/) - Displays exact, official atomic clock time for any time zone in 51 languages, covering more than 7 million locations.
 - [Time Calculator Toolkit](https://time-to-decimal.org/) - A complete browser-based toolkit for time conversion and calculation, including time-to-decimal, duration calculators, time clock rounding, time from now, and time from ago etc.
+- [Time Card Calculator](https://www.mytimecardcalculator.com/) - A quick and accurate tool to compute daily and weekly work hour totals which also supports pdf export
 
 
 ### Flight

--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ Each website is included only once. Some websites can fall into multiple categor
 - [ASCII-art Tutorial](https://stonestoryrpg.com/ascii_tutorial.html) - Tutorial on ASCII art.
 - [Emoji Combos](https://emojicombos.com/) - Collection of emoji combinations and sequences.
 - [ASCII World](https://www.asciiworld.com/) - Platform featuring ASCII art and tutorials.
-- [Rentry](https://rentry.co/FMHY) - Online collaborative markdown editor.
+- [Rentry](https://rentry.co/FMHY) - Online collaborative markdown editor.'
+- [Free Online Notepad](https://onlinenotepad101.org/) - Online Notepad – Free Online Text Editor & Notes Sharing
 
 ### Automating browser
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Every Time Zone](https://everytimezone.com/) - Visual time zone comparison for different countries.
 - [Time and Date](https://www.timeanddate.com/) - Provides calendars, clocks, and various time-related information.
 - [Time.is](https://time.is/) - Displays exact, official atomic clock time for any time zone in 51 languages, covering more than 7 million locations.
+- [Time Calculator Toolkit](https://time-to-decimal.org/) - A complete browser-based toolkit for time conversion and calculation, including time-to-decimal, duration calculators, time clock rounding, time from now, and time from ago etc.
+
 
 ### Flight
 

--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [D3.js](https://d3js.org/) - JavaScript library for manipulating documents based on data, enabling the creation of dynamic and interactive data visualizations.
 - [Deniz Cem On Duygu Portfolio](https://www.denizcemonduygu.com/) - Personal portfolio of infographics.
 - [Data Visualization Catalogue](https://datavizcatalogue.com/index.html) - Catalog providing information on various types of data visualizations.
+- [Data Viz Project](https://datavizproject.com/) - Provides a comprehensive catalogue of data visualization types accompanied by additional examples.
 - [Tableau Public](https://public.tableau.com/app/discover) - Free platform to explore, create, and publicly share data visualizations online.
 - [Will Robots Take My Job?](https://willrobotstakemyjob.com/) - Estimates the automation risk, growth, wages, and more for various jobs.
 - [Preceden](https://www.preceden.com/) - Online timeline and roadmaps maker.

--- a/README.md
+++ b/README.md
@@ -2109,6 +2109,7 @@ Each website is included only once. Some websites can fall into multiple categor
   - Do not add a website if it is malicious, dangerous, illegal, etc. (you can check its security by running it through a program such as [VirusTotal](https://www.virustotal.com/gui/home)).
   - Do not add a website if it is merely for entertainment and not really useful for anything.
   - To avoiding duplications, seach whether the website is already included.
+  - If you are a spam/AI account, your pull request is going to be rejected.
   - Create a [pull request](https://github.com/atakanaltok/awesome-useful-websites/pulls).
 
 - If you are a site owner and believe that your site is not described accurately, please [rise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Each website is included only once. Some websites can fall into multiple categor
 
 ### Texts
 
+- [Bold Text Generator](https://99tools.net/bold-text-generator/) - Easily generate bold text.
 - [Word Counter](https://freecodetools.org/word-counter/) - Word counter.
 - [Text Faces](https://textfac.es/) - Write Unicode faces.
 - [Title Case](https://titlecase.com/) - Convert a text into all kinds of cases.
@@ -2109,13 +2110,13 @@ Each website is included only once. Some websites can fall into multiple categor
 - If you want to add a new category or website:
   - Do not add a website if it is malicious, dangerous, illegal, etc. (you can check its security by running it through a program such as [VirusTotal](https://www.virustotal.com/gui/home)).
   - Do not add a website if it is merely for entertainment and not really useful for anything.
-  - To avoiding duplications, seach whether the website is already included.
+  - To avoid duplication, search whether the website is already included.
   - If you are a spam/AI account, your pull request is going to be rejected.
   - Create a [pull request](https://github.com/atakanaltok/awesome-useful-websites/pulls).
 
-- If you are a site owner and believe that your site is not described accurately, please [rise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).
+- If you are a site owner and believe that your site is not described accurately, please [raise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).
 
-- If a website is down for some reason, it is generally kept in the list for archiving purposes, and also in case their maintainers might restore them. However, if the destination of a link has changed or a link is now broken, please [rise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).
+- If a website is down for some reason, it is generally kept in the list for archiving purposes, and also in case their maintainers might restore them. However, if the destination of a link has changed or a link is now broken, please [raise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [ByClickDownloader](https://www.byclickdownloader.com/) - Backup videos from various sites in HD, MP3, MP4, AVI, and other formats using their software.
 - [Reanimate](https://reanimate.github.io/) - Build declarative animations with SVG and Haskell.
 - [Photopea](https://photopea.com/) - Free online photo editor similar to Photoshop.
+- [remove image backgrounds online for free](https://free-background-remover.com) - AI background remover that runs entirely in the browser, no upload, no sign-up, no watermark.
 
 ### Data Entry
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Bandura Festival](https://bandura.ukrzen.in.ua/en#lvivbandurfest) - Online Bandura, a traditional Ukrainian instrument.
 - [AllMusic](https://www.allmusic.com/) - Provides comprehensive and in-depth information on albums, artists, songs, and bands, serving as a valuable resource for music enthusiasts.
 - [ASMR Microphones](https://asmrmicrophones.com) - Reviews, comparisons, and expert opinions on various ASMR microphones are provided to help users select the most suitable equipment.
+- [Tonalux](https://tonalux.org/) - Browser-based audio production platform with spectrum analyzer, media converter, plugin comparer and curated plugin deals. No account required.
 
 ### Find Music
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Each website is included only once. Some websites can fall into multiple categor
 - [WordToTime](https://wordtotime.org) — Convert word/character counts or full text into estimated speaking, reading or narration time. Supports multiple languages and in-browser privacy-friendly processing.
 - [VolumeShaderBM](https://volumeshaderbm.org) — Browser-based real-time GPU volume shader benchmark with WebGPU/WebGL performance comparison.
 - [Speaking Time Calculator](https://speakingtimecalculator.org) – A free online tool to estimate speaking or presentation time from text using adjustable speaking speed (WPM).
+- [Focus Game](https://focus-game.org) - A lightweight browser-based focus training game for improving concentration through short interactive sessions.
+- [Schulte Table](https://schulte-table.org) - A web-based Schulte table tool for training visual attention, peripheral vision, and speed reading.
 
 ### White Board
 

--- a/README.md
+++ b/README.md
@@ -1583,6 +1583,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Flash Games Archive](https://flasharch.com/en) - Archive of Flash games, preserving these classic games for future enjoyment.
 - [OpenGameArt](https://opengameart.org/) - A platform offering free-to-use game assets, including 2D and 3D art, sound effects, and music for developers and game creators.
 - [Nexus Mods](https://www.nexusmods.com/) - One of the largest online communities for game modifications, offering a vast collection of mods for popular video games to enhance gameplay, add content, or personalize experiences.
+- [Noclip](https://noclip.website/) - An online videogame map viewer for exploring levels from various videogames in noclip mode.
 
 #### Game Theory
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [ByClickDownloader](https://www.byclickdownloader.com/) - Backup videos from various sites in HD, MP3, MP4, AVI, and other formats using their software.
 - [Reanimate](https://reanimate.github.io/) - Build declarative animations with SVG and Haskell.
 - [Photopea](https://photopea.com/) - Free online photo editor similar to Photoshop.
+- [Remove Audio (free tool)](https://remove-audio.com) - Strip the audio track from any video right in your browser. Runs locally with FFmpeg.wasm, no uploads, no signup, no watermark.
 
 ### Data Entry
 

--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Oh Shit, Git!](https://ohshitgit.com/) - Resource providing solutions for common Git mistakes and how to recover from them.
 - [GitHub Trending Archive](https://github.motakasoft.com/trending/) - Archive of trending repositories on GitHub, allowing users to explore popular projects and programming trends over time.
 - [Map of GitHub](https://anvaka.github.io/map-of-github/) - Visual representation of the GitHub repository network.
+- [Related Repos](https://relatedrepos.com/) - Discover related open source projects. Find alternatives and other similar repositories. Updated daily.
 
 ### IDEs
 

--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Cool Startup Jobs](https://www.coolstartupjobs.com/) - Explore job opportunities in growing startups and give your stock options a chance.
 - [Anon Friendly](https://anonfriendly.com/) - Find jobs that respect your desire for anonymity.
 - [Prompt Engineering Jobs](https://prompt-engineering-jobs.com) - Explore engineering job opportunities with Prompt.
+- [AI Dev Jobs](https://aidevboard.com) - AI/ML-focused job board with 7,700+ positions from 440+ companies, including a free REST API and MCP server for AI-powered job search.
 - [KeyValues](https://www.keyvalues.com/) - Find engineering teams that align with your values.
 - [About.me](https://about.me/) - Platform for freelancers and entrepreneurs to grow their audience and attract clients.
 - [Rejected.us](https://rejected.us/) - Read and share stories of job rejections.
@@ -1753,6 +1754,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [XN--1-ZFA](https://xn--1-zfa.com/) - Advanced search for Google, DuckDuckGo, Twitter, YouTube, Reddit.
 - [Seekr](https://www.seekr.com/) - Search engine that utilizes AI to analyze and score the quality of content, starting with news articles.
 - [Million Short](https://millionshort.com/) - Discover content beyond the first million search results.
+- [Not Human Search](https://nothumansearch.ai) - Search engine for AI agent tools, indexing 1,750+ MCP servers and developer APIs with agentic compatibility scores.
 
 ### Internet
 

--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Bandura Festival](https://bandura.ukrzen.in.ua/en#lvivbandurfest) - Online Bandura, a traditional Ukrainian instrument.
 - [AllMusic](https://www.allmusic.com/) - Provides comprehensive and in-depth information on albums, artists, songs, and bands, serving as a valuable resource for music enthusiasts.
 - [ASMR Microphones](https://asmrmicrophones.com) - Reviews, comparisons, and expert opinions on various ASMR microphones are provided to help users select the most suitable equipment.
+- [Omnichord Online](https://www.omnichordonline.com) - It is an online simulator for the classic instrument **Omnichord OM-27**. You can play it anytime for free in your PC or mobile browser, enjoying its authentic sound and the joy of creation.
 
 ### Find Music
 

--- a/README.md
+++ b/README.md
@@ -706,6 +706,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Y Combinator Jobs](https://www.ycombinator.com/jobs) - Discover the best startup jobs curated by Y Combinator.
 - [Coroflot](https://www.coroflot.com/discover) - Job search platform specifically tailored for designers.
 - [Cool Startup Jobs](https://www.coolstartupjobs.com/) - Explore job opportunities in growing startups and give your stock options a chance.
+- [Hanzilla Jobs](https://jobs.hanzilla.co/) - Free daily-updated Canadian student and recent-graduate jobs board for internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more.
 - [Anon Friendly](https://anonfriendly.com/) - Find jobs that respect your desire for anonymity.
 - [Prompt Engineering Jobs](https://prompt-engineering-jobs.com) - Explore engineering job opportunities with Prompt.
 - [KeyValues](https://www.keyvalues.com/) - Find engineering teams that align with your values.

--- a/README.md
+++ b/README.md
@@ -1287,6 +1287,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Engineer on a Disk: Modeling](https://engineeronadisk.com/book_modeling/modelTOC.html) - A book offering a hands-on guide to system modeling and simulation, with practical examples and explanations for engineers and developers.
 - [Bartosz Ciechanowski Archives](https://ciechanow.ski/archives/) - Collection of articles on design and technology by Bartosz Ciechanowski.
 - [IQS Directory Articles](https://www.iqsdirectory.com/articles/) - Industrial components explained through technical articles and manufacturer insights.
+- [Printable Graph Paper](https://printablegraphpaper.org/) - Printable Graph Paper with various templates
 
 ### Civil Engineering
 

--- a/README.md
+++ b/README.md
@@ -1389,6 +1389,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Colah's Blog](https://colah.github.io/) - Blog by Christopher Olah on deep learning and artificial intelligence, featuring detailed explanations, tutorials, and research insights.
 - [TensorFlow Playground](https://playground.tensorflow.org) - An interactive tool for experimenting with neural networks, allowing users to visualize how different configurations affect model training and classification tasks.
 - [Future Tools](https://www.futuretools.io/) - Platform for finding the exact AI tool for your needs.
+- [AIPower.spot](https://aipower.spot/) - This is an online catalog and platform for searching and selecting tools based on artificial intelligence (AI).
 - [AI Tools Arena](https://aitoolsarena.com/) - Platform showcasing various AI tools and resources.
 - [Aiva Valley](https://aivalley.ai/) - The latest source of AI tools and prompts.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2139 @@
+# Awesome Useful Websites
+
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+
+<br>
+
+Explore the internet's hidden gems with this list of awesome useful websites!
+
+<br>
+
+Most of these websites are gathered from:
+
+- [producthunt.com](https://www.producthunt.com/)
+- [reddit.com/r/InternetIsBeautiful](https://www.reddit.com/r/InternetIsBeautiful/)
+- [news.ycombinator.com](https://news.ycombinator.com/)
+- [x.com/IndieRandWeb](https://x.com/IndieRandWeb)
+
+<br>
+
+Feel free to share this list, star it, and [contribute](#contributing) your own awesome finds.
+
+<br>
+
+## Nomenclature
+
+Certain websites are tagged with the symbols listed below for convenience.
+
+| Symbol | Meaning                                                                                          |
+| :----: | ------------------------------------------------------------------------------------------------ |
+|   $    | Payment Required (There are no free options)                                                     |
+|   @    | Student Friendly (Offers discounts or a free version for students)                               |
+|   !    | Website Down (The website is down for some reason, see the end of [contributing](#contributing)) |
+
+<br>
+
+Each website is included only once. Some websites can fall into multiple categories. If you can't find what you need in a specific category, search for keywords or explore other relevant categories as well. To look up websites, use the [raw](https://raw.githubusercontent.com/atakanaltok/awesome-useful-websites/refs/heads/main/README.md) version.
+
+# Contents
+
+- [Awesome Useful Websites](#awesome-useful-websites)
+  - [Nomenclature](#nomenclature)
+- [Contents](#contents)
+  - [Tools](#tools)
+    - [White Board](#white-board)
+    - [Mind Map / Note Taking](#mind-map--note-taking)
+    - [Diagrams](#diagrams)
+    - [Texts](#texts)
+    - [Automating browser](#automating-browser)
+    - [Comparison](#comparison)
+    - [File](#file)
+    - [Visual](#visual)
+    - [Data Entry](#data-entry)
+  - [DIY](#diy)
+  - [Culture](#culture)
+  - [Language](#language)
+    - [Grammar](#grammar)
+    - [Words \& Meanings](#words--meanings)
+  - [Travel](#travel)
+    - [Globetrotting](#globetrotting)
+    - [Time](#time)
+    - [Flight](#flight)
+    - [Weather](#weather)
+  - [Health](#health)
+    - [Air Quality](#air-quality)
+    - [Food](#food)
+    - [Lawn/Yard care](#lawnyard-care)
+  - [Music / Audio](#music--audio)
+    - [Find Music](#find-music)
+    - [Free Music](#free-music)
+    - [Mix Sounds](#mix-sounds)
+    - [Music Theory](#music-theory)
+      - [Rhyme](#rhyme)
+    - [Spotify](#spotify)
+  - [Movies and Series](#movies-and-series)
+    - [Anime](#anime)
+  - [Media](#media)
+    - [X / Twitter](#x--twitter)
+    - [Reddit](#reddit)
+    - [Discord](#discord)
+  - [Economy](#economy)
+  - [Business](#business)
+    - [Finance](#finance)
+    - [Patents](#patents)
+    - [Marketing](#marketing)
+      - [Social Media](#social-media)
+    - [Trends](#trends)
+    - [Meetings](#meetings)
+  - [Jobs](#jobs)
+    - [Remote Jobs](#remote-jobs)
+    - [Freelancing](#freelancing)
+    - [Portfolio / CV / Resume](#portfolio--cv--resume)
+    - [Careers](#careers)
+  - [Startups](#startups)
+    - [Failures](#failures)
+    - [Finding Ideas](#finding-ideas)
+    - [Connectivity](#connectivity)
+    - [Design](#design)
+      - [Colors](#colors)
+      - [Fonts](#fonts)
+      - [Icons / Icon Packs](#icons--icon-packs)
+      - [Stock Images](#stock-images)
+      - [Wallpapers](#wallpapers)
+  - [Art](#art)
+    - [Photography](#photography)
+    - [Art Communities](#art-communities)
+  - [Academia](#academia)
+    - [Studying](#studying)
+    - [Calculators](#calculators)
+    - [MOOC (Massive Open Online Courses)](#mooc-massive-open-online-courses)
+  - [Science](#science)
+    - [Biographies](#biographies)
+    - [Books, Articles, Texts](#books-articles-texts)
+      - [Book Recommendations and Summaries](#book-recommendations-and-summaries)
+    - [Maps and Data](#maps-and-data)
+      - [Arxiv](#arxiv)
+    - [Infographic](#infographic)
+    - [Philosophy](#philosophy)
+    - [Social Sciences](#social-sciences)
+    - [History](#history)
+    - [Geoscience](#geoscience)
+    - [Biology](#biology)
+  - [Physics](#physics)
+    - [Quantum](#quantum)
+      - [Quantum Games](#quantum-games)
+    - [Astronomy](#astronomy)
+  - [Mathematics](#mathematics)
+    - [Math + Art](#math--art)
+  - [Engineering](#engineering)
+    - [Civil Engineering](#civil-engineering)
+    - [Mechanical Engineering](#mechanical-engineering)
+      - [Materials / Nanotechnology](#materials--nanotechnology)
+    - [Electronics Engineering](#electronics-engineering)
+  - [Computer Science](#computer-science)
+    - [Data Structures and Algorithms (DS\&A)](#data-structures-and-algorithms-dsa)
+    - [Big-O notation](#big-o-notation)
+  - [AI/ML](#aiml)
+    - [Robotics](#robotics)
+    - [LLMs](#llms)
+      - [Prompt Engineering](#prompt-engineering)
+    - [AI tools](#ai-tools)
+    - [Data Science](#data-science)
+    - [Databases](#databases)
+  - [Web Development](#web-development)
+    - [Domain](#domain)
+    - [Front-end](#front-end)
+      - [HTML](#html)
+      - [CSS](#css)
+      - [JavaScript](#javascript)
+    - [Back-End](#back-end)
+      - [APIs](#apis)
+      - [SQL](#sql)
+    - [Web Analytics](#web-analytics)
+      - [Testing](#testing)
+    - [Web 3.0 Dev and Cryptocurrencies](#web-30-dev-and-cryptocurrencies)
+  - [Software Engineering](#software-engineering)
+    - [Android Development](#android-development)
+    - [Game Development](#game-development)
+      - [Game Theory](#game-theory)
+      - [Pokemon](#pokemon)
+      - [Chess](#chess)
+    - [Embeddings](#embeddings)
+    - [Linux](#linux)
+    - [Vim](#vim)
+    - [Git](#git)
+    - [GitHub](#github)
+    - [IDEs](#ides)
+  - [Privacy](#privacy)
+    - [Cryptography](#cryptography)
+    - [GAFA Alternatives](#gafa-alternatives)
+    - [Ad Blocker](#ad-blocker)
+    - [Emails](#emails)
+      - [Disposable Email](#disposable-email)
+    - [Data Breach](#data-breach)
+    - [Search](#search)
+    - [Internet](#internet)
+      - [DNS](#dns)
+    - [URL](#url)
+      - [URL Shortener](#url-shortener)
+    - [VPN](#vpn)
+    - [Fake Information Generation](#fake-information-generation)
+    - [Password Generation](#password-generation)
+  - [Softwares](#softwares)
+    - [Snippets](#snippets)
+    - [Linters](#linters)
+    - [Testing](#testing-1)
+    - [Regex](#regex)
+    - [No-Code](#no-code)
+      - [Licensing](#licensing)
+  - [Programming Languages](#programming-languages)
+    - [Haskell](#haskell)
+    - [Python](#python)
+    - [C++](#c)
+  - [Coding Practice / Competitive Programming](#coding-practice--competitive-programming)
+    - [Capture the Flag](#capture-the-flag)
+    - [Projects](#projects)
+    - [Open Source](#open-source)
+    - [Hackathons](#hackathons)
+  - [Cheat Sheets](#cheat-sheets)
+    - [Python Cheat Sheet](#python-cheat-sheet)
+    - [Front-end Cheat Sheet](#front-end-cheat-sheet)
+      - [HTML Cheat Sheet](#html-cheat-sheet)
+      - [CSS Cheat Sheet](#css-cheat-sheet)
+  - [Building Computer / PC Build](#building-computer--pc-build)
+    - [Keyboard](#keyboard)
+      - [Typing Practice](#typing-practice)
+      - [Keyboard Shortcuts](#keyboard-shortcuts)
+  - [Other Websites of Websites](#other-websites-of-websites)
+- [Contributing](#contributing)
+- [DISCLAIMER](#disclaimer)
+- [LICENSE](#license)
+
+<br>
+
+## Tools
+
+- [5000Best Tools](https://5000best.com/tools/) - 5000 tools.
+- [10015.io](https://10015.io/) - Free all-in-one toolbox for various tasks.
+- [UnTools](https://untools.co/) - Collection of thinking tools and frameworks.
+- [TimeTravel Memento](https://timetravel.mementoweb.org/) - Find Mementos in Internet Archive, Archive-It, British Library, archive.today, GitHub, and more.
+- [discu.eu](https://discu.eu/) - Keep up with the topics you care about through weekly newsletter, social & bots, browser extensions, bookmarklet.
+- [PromoWizard](https://promowizard.softr.app/) - Get promo codes without consuming hours of content on YouTube.
+- [Everybodywiki](https://en.everybodywiki.com/Everybodywiki:Welcome) - Rescues deleted articles and rejected drafts from Wikipedia in multiple languages and welcomes new articles.
+- [Lunar](https://lunar.fyi/) - Multi-featured app for controlling monitors.
+- [GetHuman](https://gethuman.com/) - Get a representative on the phone faster and receive better help from known companies.
+- [S-ings Scratchpad](https://www.s-ings.com/scratchpad/) - Online scratchpad tool designed for quick notes, calculations, and informal writing.
+- [UFreeTools](https://www.ufreetools.com/) - Your Online Free Toolkit.
+- [Play Go Hub](https://playgohub.com/) - Professional Gaming Tools & Guides
+- [rtcd.io](https://rtcd.io/) - Free online toolkit for audio editing, image processing, development and more.
+
+### White Board
+
+- [TypeHere](https://typehere.co/) - Blank website where you can only type.
+- [PixelPaper](https://pixelpaper.io/) - Free-forever digital whiteboard with no registration, can be embedded into SaaS products.
+- [Excalidraw](https://excalidraw.com/) - Whiteboard where you can sketch hand-drawn-like diagrams.
+- [Excalideck](https://excalideck.com/) - App for authoring slide decks that look hand-drawn, based on Excalidraw.
+- [Blank Page](https://blank.page/) - Simple webpage displaying a blank white page.
+- [Kid Pix](https://kidpix.app/) - A bitmap drawing program designed for children, offering a fun, user-friendly interface for creative and interactive digital artwork.
+- [Krita](https://krita.org/en/) - Free, open-source digital painting software designed for artists, offering advanced tools for illustration, concept art, and texture painting.
+
+### Mind Map / Note Taking
+
+- [Relanote](https://relanote.com/) - Interlinking your notes to develop a web of thoughts.
+- [Bubbl.us](https://bubbl.us/) - Mind Mapping Online.
+- [MindMup](https://www.mindmup.com/) - Free online mind mapping.
+- [Anotepad](https://anotepad.com/) - Online notepad. No login. Download your note as PDF or Word document.
+- [Notes.io](https://notes.io/) - Web-based application for taking notes.
+
+### Diagrams
+
+- [Creately](https://creately.com/) - Data-connected Visual Workspace for brainstorming, planning, executing, and capturing knowledge.
+- [draw.io](https://www.drawio.com/) - Open-source, security-first technology stack for building diagramming applications. For [web usage](https://app.diagrams.net/?src=about).
+- [OrgPad](https://orgpad.com/?ref=producthunt) - An interactive online mind map.
+- [Lucidchart](https://www.lucidchart.com/pages/) - A diagramming and flowchart app that brings teams together to make better decisions and build the future.
+- [Learn Anything](https://learn-anything.xyz/) - Platform for organizing the world's knowledge, exploring connections, and curating learning paths.
+
+### Texts
+
+- [Word Counter](https://freecodetools.org/word-counter/) - Word counter.
+- [Text Faces](https://textfac.es/) - Write Unicode faces.
+- [Title Case](https://titlecase.com/) - Convert a text into all kinds of cases.
+- [Fancy Text Generator](https://lingojam.com/FancyTextGenerator) - Convert a text into all kinds of fonts.
+- [Calligraphr](https://www.calligraphr.com/en/) - Transform your handwriting or calligraphy into a font.
+- [Dongerlist](https://dongerlist.com/) (!) - Set of Unicode characters assembled to form a text emoticon.
+- [ASCII-art Tutorial](https://stonestoryrpg.com/ascii_tutorial.html) - Tutorial on ASCII art.
+- [Emoji Combos](https://emojicombos.com/) - Collection of emoji combinations and sequences.
+- [ASCII World](https://www.asciiworld.com/) - Platform featuring ASCII art and tutorials.
+- [Rentry](https://rentry.co/FMHY) - Online collaborative markdown editor.
+
+### Automating browser
+
+- [Automa](https://chrome.google.com/webstore/detail/automa/infppggnoaenmfagbfknfkancpbljcca?ref=producthunt) - Chrome extension for automating your browser.
+- [Browse.AI](https://www.browse.ai/) - Platform to extract, set up clicks, and monitor data from any website.
+- [Tango](https://www.tango.us/) - Tool to create step-by-step documentation, how-to playbooks, and product guides with screenshots.
+- [BookmarkOS](https://bookmarkos.com/bookmark-manager-finder) - Allows you to filter through various bookmark managers.
+
+### Comparison
+
+- [Social Media Messaging Apps Comparison](https://docs.google.com/spreadsheets/d/1-UlA4-tslROBDS9IqHalWVztqZo7uxlCeKPQ-8uoFOU/edit#gid=0) - Detailed comparison and analysis of social media messaging apps.
+- [DxOMark](https://www.dxomark.com/category/smartphone-reviews/) - Scientific tests and data on smartphones, sensors, lenses, and speakers.
+- [TechSpecs Compare Phones](https://techspecs.io/vs/) - Compare specifications of phones.
+- [TechSpecs](https://techspecs.io/) - Search engine for consumer electronics products.
+- [Kimovil](https://www.kimovil.com/en/) - Compare specifications and prices of smartphones and tablets.
+- [DiffChecker](https://www.diffchecker.com/) - Compare text, image, PDF, and more to find differences between files.
+- [CodingFont](https://www.codingfont.com/) - Gamified experience to compare and find coding fonts.
+- [This vs That](https://thisvsthat.io/) - Type in two things to compare them to each other.
+- [Secure Messaging Apps Comparison](https://www.securemessagingapps.com/) - A comparison platform for secure messaging apps.
+- [RTINGS](https://www.rtings.com/) - Provides in-depth reviews and comparisons of audio and visual equipment, including TVs, monitors, headphones, and soundbars, with detailed testing and ratings.
+
+### File
+
+- [Wormhole](https://wormhole.app/) - Platform to share files with end-to-end encryption and a link that automatically expires.
+- [Keybase](https://keybase.io/) - End-to-end encrypted secure messaging and file-sharing.
+- [MediaFire](https://www.mediafire.com/) - File storage and sharing platform (with subscription options).
+- [Zippyshare](https://www.zippyshare.com/) - File-sharing service with no sign-up required, no download limits, free, and unlimited disk space.
+
+### Visual
+
+- [Unscreen](https://www.unscreen.com/) - Remove video background automatically and for free.
+- [Remove.bg](https://www.remove.bg/) - Remove image background automatically and for free.
+- [Foco Clipping](https://www.fococlipping.com/) - Remove image background.
+- [Designify](https://www.designify.com/) ($) - Create AI-powered designs by automatically removing backgrounds, enhancing colors, adjusting smart shadows, and more.
+- [PfpMaker](https://pfpmaker.com/) - Make profile pictures from any photo.
+- [JPEG-Optimizer](https://jpeg-optimizer.com/) - Free online tool for resizing and compressing digital photos and images.
+- [Extract.pics](https://extract.pics/) - Extract images from any public website using a virtual browser.
+- [Generated.Photos](https://generated.photos/) - Unique, worry-free (AI-generated), free to download model photos.
+- [Zoom.it](https://zoom.it/) - Create high-resolution, zoomable images.
+- [VectorMagic](https://vectormagic.com/) - Convert bitmaps (JPG, PNG, GIF) to vectors (PDF, SVG, EPS).
+- [Screenshot.Guru](https://screenshot.guru/) - Take high-resolution screen captures of websites and tweets.
+- [Stolen Camera Finder](https://www.stolencamerafinder.com/) - Use the serial number stored in your photos to search the web for other photos taken with the same camera.
+- [Ribbet](https://www.ribbet.com/) - Photo editing tools.
+- [Crossfade.io](https://crossfade.io/) - Web-based video mashups from your favorite sites.
+- [GoProHeroes](https://goproheroes.com/) - GoPro videos across the web.
+- [Synthesia](https://www.synthesia.io/) ($) - AI video creation platform that creates videos from text in minutes.
+- [ClipDrop](https://clipdrop.co/) - Create stunning visuals in seconds, powered by AI.
+- [Reface](https://hey.reface.ai/) - Create face swap videos, a mobile app powered by AI.
+- [PhotoSonic](https://photosonic.writesonic.com/) - AI that paints your dreams with pixels, another version of DALL-E.
+- [Shottr](https://shottr.cc/) - Tiny and fast macOS screenshot tool with annotations, scrolling screenshots, and cloud upload capabilities.
+- [3D GIF Maker](https://www.3dgifmaker.com/) - Create 3D GIFs easily from your images.
+- [EZGIF](https://ezgif.com/) - Online GIF maker and image editor for creating and editing GIFs.
+- [PimEyes](https://pimeyes.com/en) - Facial recognition search engine and reverse image search for finding images containing a specific person.
+- [Visual Illusions](https://sites.socsci.uci.edu/~ddhoff/illusions.html) - Collection of visual illusions and demonstrations.
+- [ByClickDownloader](https://www.byclickdownloader.com/) - Backup videos from various sites in HD, MP3, MP4, AVI, and other formats using their software.
+- [Reanimate](https://reanimate.github.io/) - Build declarative animations with SVG and Haskell.
+- [Photopea](https://photopea.com/) - Free online photo editor similar to Photoshop.
+
+### Data Entry
+
+- [XLSXForm](https://xlsxform.com/) - Build forms and store all data entry in .xlsx file format.
+
+## DIY
+
+- [WikiHow](https://www.wikihow.com/Main-Page) - A collaborative platform for creating and sharing how-to guides.
+- [ManualsLib](https://www.manualslib.com/) - Online repository of user manuals and guides.
+- [This to That](https://thistothat.com/) - Learn how to glue different materials together.
+- [HowStuffWorks](https://www.howstuffworks.com/) - Explore how things work with in-depth explanations and articles.
+- [WonderHowTo](https://www.wonderhowto.com/) - Learn how to do almost anything with instructional videos and step-by-step guides.
+- [Dummies](https://www.dummies.com/) - A series of instructional/reference books.
+- [DoItYourself](https://www.doityourself.com/) - Resources for DIY projects and home improvement.
+- [JScreenFix](https://www.jscreenfix.com/) - Pixel fixing algorithm for repairing defective pixels, particularly effective for stuck pixels. No installation required, and it's free.
+- [Donkey Car](https://www.donkeycar.com/) - Open-source DIY self-driving platform for small-scale cars. It combines an RC car with a Raspberry Pi and is powered by Python (tornado, keras, tensorflow, opencv, etc.).
+- [Instructables](https://www.instructables.com/) - A platform for discovering and sharing DIY projects.
+- [iFixit](https://www.ifixit.com/) - Provides free repair guides and manuals for a wide variety of electronics, appliances, and other products, empowering users to fix items themselves, contributed by the community.
+- [Fix It Club](https://fixitclub.com/) - Save money on home repairs with helpful guides.
+- [BookCrossing](https://bookcrossing.com/) - Release your books "into the wild" for strangers to find or perform a "controlled release" to another BookCrossing member, and track their journey via journal entries from around the world.
+- [Dimensions](https://www.dimensions.com/) - Platform offering visual reference designs for dimensions and measurements across various categories.
+- [Repair Clinic](https://www.repairclinic.com/) - Longest-running source for genuine appliance, HVAC, and outdoor power equipment parts in North America, offering expert advice, how-to resources, and support for DIY repairs. Trusted by professionals and homeowners, the site provides high-quality OEM parts and guidance to help users successfully complete their repairs.
+
+## Culture
+
+- [Cultural Atlas](https://culturalatlas.sbs.com.au/) - Educational resource providing comprehensive information on cultural backgrounds.
+- [QuoteMaster](https://www.quotemaster.org/) - Platform with 98,683 categories and 1,488,431 quotes.
+- [FactSlides](https://www.factslides.com/) - Offers 1001 facts about various topics with sources.
+- [Starkey Comics](https://starkeycomics.com/) - Website featuring colorful images and posts about culture and language.
+- [Unusual Wikipedia Articles](https://en.wikipedia.org/wiki/Wikipedia:Unusual_articles) - Compilation of unusual Wikipedia articles.
+- [List of Common Misconceptions](https://en.wikipedia.org/wiki/List_of_common_misconceptions) - Wikipedia page listing common misconceptions.
+- [Behind the Name](https://www.behindthename.com/) - Provides etymology and history of first names.
+- [Behind the Surname](https://surnames.behindthename.com/) - Offers etymology and history of surnames.
+- [Nameberry](https://nameberry.com/) - Platform for baby names by experts, including popular names, unique names, baby girl names, baby boy names, and gender-neutral names.
+- [Library of Juggling](https://libraryofjuggling.com/) - Online resource of list all of the popular (and perhaps not so popular) juggling tricks in one organized place.
+- [Toaster Central](https://toastercentral.com/) - Collection of working vintage toasters.
+- [All About Berlin](https://allaboutberlin.com/) - Platform offering guides and information for individuals planning to settle in Berlin. Includes details about obtaining visas, finding jobs, securing apartments, and more.
+- [Unita](https://unita.co/) - Platform to discover, compare, and review the best communities, masterminds, and online groups across more than 30+ categories.
+- [Escape Room Tips](https://escaperoomtips.com/) - Tips, tricks, and puzzles for escape rooms
+
+## Language
+
+- [YouGlish](https://youglish.com/) - Use YouTube to improve your English pronunciation.
+- [Voscreen](https://www.voscreen.com/) - Platform providing video snippets of English sentences; test your understanding by choosing paraphrased sentences.
+- [News in Levels](https://www.newsinlevels.com/) - World news tailored for students of English.
+- [Pink Trombone](https://dood.al/pinktrombone/) - Interactive simulation of the human mouth and its sounds using an animated voicebox.
+- [Japanese Wiki Corpus](https://www.japanese-wiki-corpus.org/) - Resource generated from the Japanese-English Bilingual Corpus of Wikipedia's Kyoto Articles.
+- [Latin Phrases](https://latin-phrases.co.uk/) - Reference to look up translations of Latin phrases.
+- [Prismatext](https://prismatext.com/) - Blend the most useful foreign words and phrases into your favorite novels and stories.
+- [Ponly](https://ponly.com/about/) - Website with fun and humorous content and jokes.
+- [Tongue-Twister](https://tongue-twister.net/) - World's largest collection of tongue twisters with 3660 entries in 118 languages
+- [OLAC (Open Language Archives Community)](http://olac.ldc.upenn.edu/) - An international network of institutions and individuals working to create a global virtual library of language resources, focusing on digital archiving practices and providing interoperable repositories for accessing linguistic data.
+- [US Dictionary](https://usdictionary.com/) - Word meanings, synonyms, and usage examples provided for American English terms.
+
+### Grammar
+
+- [GrammarBook](https://www.grammarbook.com/english_rules.asp) - Comprehensive guide to English grammar rules.
+- [The Punctuation Guide](https://www.thepunctuationguide.com/index.html) - Resource offering a guide to American punctuation rules.
+- [Progressive Punctuation](https://progressivepunctuation.com/) - Collection of non-standard punctuation marks.
+- [Purdue OWL](https://owl.purdue.edu/site_map.html) - Purdue University's Online Writing Lab, providing resources on writing, grammar, and citation styles.
+- [Towson University Online Writing Support](https://webapps.towson.edu/ows/index.asp) - Online writing support and grammar resources.
+- [Grammar Monster](https://www.grammar-monster.com/index.html) - Platform offering free English grammar lessons and tests.
+- [Fraze It](https://fraze.it/) - Platform with more than 100 millions sentences.
+
+### Words & Meanings
+
+- [Educalingo](https://educalingo.com/en/dic-en) - Platform to find synonyms, uses, trends, statistics, and more for words.
+- [Fine Dictionary](https://www.finedictionary.com/) - Comprehensive information about a word.
+- [Crown Academy English](https://www.crownacademyenglish.com/articles/) - Provides simple, succinct, and clear explanations of various English language concepts.
+- [Ask Difference](https://www.askdifference.com/) - Offers short and concise differences between two similar subjects.
+- [Key Differences](https://keydifferences.com/) - Website focused on presenting differences and comparisons.
+- [DifferenceBetween.info](https://www.differencebetween.info/) - Provides descriptive analysis and comparisons between different concepts.
+- [Wayne State University's List of Words](https://wordwarriors.wayne.edu/list) - A compilation of words that deserve wider use, curated by Wayne State University.
+- [All Acronyms](https://www.allacronyms.com/) - Community-driven acronyms and abbreviations dictionary.
+- [How to Professionally Say](https://howtoprofessionallysay.akashrajpurohit.com/) - A guide for your daily professional interactions, helping you navigate various situations with a professional tone.
+- [Business English Resources](https://www.businessenglishresources.com/) - A collection of free resources for improving your business English skills.
+- [Digital Glossary](https://www.digital-glossary.com/) - Provides terminological words in Turkish, English, and German for digital contexts.
+- [Bilim Terimleri](https://terimler.org/) - Turkish platform providing explanations and definitions for various terms.
+
+## Travel
+
+- [Airheart - Travel Restrictions](https://airheart.com/travel-restrictions/united-states-vaccinated) - Stay informed about travel restrictions and requirements for your trip, including COVID-19 restrictions.
+- [Country Code](https://countrycode.org/) - A guide to call anywhere in the world, providing country codes for international dialing.
+- [Passport Index](https://www.passportindex.org/) - Explore information about passports from around the world, including rankings and details.
+- [Countries Been](https://www.countriesbeen.com/) - A mobile app to track and list the countries you have visited, offering various features.
+- [Couchsurfing](https://www.couchsurfing.com/) - Connect with a global community of people who share their homes and experiences for free.
+- [Puffin Maps](https://www.puffinmaps.com/) - An all-in-one trip planner with no ads, helping you organize your travel plans.
+- [AllTrails](https://www.alltrails.com/) - Explore a database of 300k trails with reviews and photos from outdoor enthusiasts.
+- [Wanderprep](https://www.wanderprep.com/) - Previously provided advice on gear, apps, and travel tips for smarter journeys.
+- [Looria](https://looria.com/) - A trusted platform to find honest product information.
+- [Trip Destination App (iOS)](https://apps.apple.com/us/app/id1580599572) - A free iPhone app for searching and planning trip destinations.
+- [Freecycle](https://www.freecycle.org/) - A network for people giving and getting items for free in their local communities.
+- [Roadtrippers](https://roadtrippers.com/) - Plan your route and use turn-by-turn navigation to explore various attractions on your road trip.
+- [Mountain Project](https://www.mountainproject.com/) - A free, crowd-sourced guide to climbing destinations around the world.
+- [Welcome to My Garden](https://welcometomygarden.org/) - A non-profit network offering free camping spots in private gardens for slow travelers.
+- [Warmshowers](https://www.warmshowers.org/) - A community of bicycle tourists and hosts supporting them during their journeys.
+- [Slowby](https://www.slowby.travel/) - A platform offering highly-curated slow travel trips for a unique travel experience.
+
+### Globetrotting
+
+- [Random Street View](https://randomstreetview.com/) - Explore streets from around the world without leaving home.
+- [Virtual Vacation](https://virtualvacation.us/) - Take a virtual tour around the globe from the comfort of your home.
+- [MapCrunch](https://www.mapcrunch.com/) - Experience the world through Google Street View by teleporting to random locations.
+
+### Time
+
+- [Every Time Zone](https://everytimezone.com/) - Visual time zone comparison for different countries.
+- [Time and Date](https://www.timeanddate.com/) - Provides calendars, clocks, and various time-related information.
+- [Time.is](https://time.is/) - Displays exact, official atomic clock time for any time zone in 51 languages, covering more than 7 million locations.
+
+### Flight
+
+- [SeatGuru](https://seatguru.com/) - Explore 1,278 aircraft's seat maps to find yours.
+- [Flightradar24](https://www.flightradar24.com/43,24.35/7) - Global flight tracking service providing real-time information about thousands of aircraft around the world.
+- [Skyscanner](https://www.skyscanner.co.in/) - Flight search engine allowing users to search for flights by date, price, and budget.
+
+### Weather
+
+- [Hint.fm Wind Map](https://hint.fm/wind/) - Delicate tracery of wind flowing over the US.
+- [Windy](https://www.windy.com/) - Comprehensive information about the weather for any location.
+- [Zoom Earth](https://zoom.earth/) - Real-time visualization of the world, tracking tropical storms, hurricanes, severe weather, wildfires, and more.
+- [Earth Nullschool](https://earth.nullschool.net/) - Visualization of global weather conditions forecast by supercomputers, updated every three hours.
+- [OpenWeatherMap](https://openweathermap.org/) - Platform providing weather forecasts, newscasts, and historical weather data in a fast and elegant way.
+- [Radiosondy](https://radiosondy.info/) - Tracks meteorological radiosondes, providing a database of current and past radiosonde flights, including information such as launch site, type, last frame, course, speed, altitude, and frequency. (Note: A radiosonde is a battery-powered telemetry instrument usually carried into the atmosphere by a weather balloon.)
+
+## Health
+
+- [MuscleWiki](https://musclewiki.com/) - Platform to learn about your body and muscles.
+- [Just a Minute](https://jinay.dev/just-a-minute/) - Test your chronoception (sense of passing time) in one minute.
+- [FutureMe](https://www.futureme.org/) - Platform to write a letter to your future self.
+- [Strobe.Cool](https://strobe.cool/) - Create visual stimuli using strobe effects.
+- [UnTools](https://untools.co/) - Collection of thinking tools and frameworks to assist in problem-solving, decision-making, and understanding systems.
+- [Puzzle Loop](https://www.puzzle-loop.com/) - Platform offering logic puzzles with simple rules and challenging solutions.
+- [What Should You Do with Your Life?](https://guzey.com/personal/what-should-you-do-with-your-life/) - Article providing directions and advice on life decisions.
+- [InnerBody](https://www.innerbody.com/) - Research for reviews and researches about health products, services, and more.
+- [Sleep Calculator](https://sleepcalculator.com/) - Tool that helps users determine the best time to go to bed based on their desired wake-up time, optimizing sleep cycles for better rest and alertness.
+- [SimpleLab](https://gosimplelab.com/) - Provides rapid, reliable environmental testing across the U.S., using a cloud-based platform for efficient sampling, testing, and data management.
+- [Sleep Estimator](https://www.sleep-estimator.com/) - Calculates the best bedtime based on your wake-up time to optimize sleep quality and alertness.
+- [Sleep Calculator App](https://sleepcalculatorapp.com/) - Find Your Ideal Sleep and Wake Time.
+- [Sleep Cyclecalc App](http://sleepcyclecalcapp.com/) - Find Your Best Sleep Schedule
+- [Sleep Time Calculator](https://www.sleeptimecalculator.org/) - Find Your Perfect Sleep Time
+
+### Air Quality
+
+- [Air Quality Index (European Environment Agency)](http://airindex.eea.europa.eu/) - Provides real-time air quality data across Europe, featuring an interactive map that visualizes air pollution levels and their impact on public health.
+- [Berkeley Earth](http://berkeleyearth.org/) - A non-profit organization focused on providing accurate and comprehensive data on air quality and climate, with tools for visualizing environmental data globally.
+- [World Air Quality Index](https://waqi.info/) - Offers real-time air quality information from around the world, providing an interactive map and detailed data on pollution levels and their effects on health.
+- [IQAir](https://www.iqair.com/) - Operates the world’s largest free real-time air quality monitoring platform, providing critical data to individuals, researchers, and governments to monitor and address air pollution, ultimately helping to protect global public health.
+
+### Food
+
+- [GoBento](https://www.gobento.com/) - Engagement platform focused on improving the health and well-being of at-risk members, particularly those experiencing food insecurity.
+- [MyFridgeFood](https://myfridgefood.com/) - Platform that allows users to check off ingredients they have to find recipes they can make with those ingredients.
+- [Just the Recipe](https://www.justtherecipe.com/) - Platform that provides direct instructions from any recipe site without ads and pop-ups.
+- [Two Peas and Their Pod](https://www.twopeasandtheirpod.com/) - Recipe site offering a variety of recipes.
+- [HelloFresh](https://www.hellofresh.com/) - Meal kit delivery service where users can choose recipes, and HelloFresh delivers the ingredients straight to their door.
+
+### Lawn/Yard care
+
+- [Healthy Yards](https://healthyyards.org) - Resources and tips for eco-friendly and sustainable lawn care practices are offered, with a focus on benefiting local wildlife and the environment.
+- [Homegrown National Park](https://homegrownnationalpark.org) - Information on creating wildlife corridors and contributing to biodiversity by planting native species is provided.
+- [Butterfly Conservation](https://butterfly-conservation.org) - Details on the conservation of butterflies and moths are shared, including species protection and involvement opportunities.
+- [Xerces Society](https://xerces.org) - Guidance on the conservation of pollinators and invertebrates, including habitat restoration and sustainable practices, is available.
+- [Beyond Pesticides](https://beyondpesticides.org) - Resources on organic and sustainable practices for reducing pesticide use and protecting public health and the environment are provided.
+- [National Pesticide Information Center](https://npic.orst.edu) - Science-based information on pesticide use, safety guidelines, and factsheets for consumers and health professionals is offered.
+
+## Music / Audio
+
+- [KHInsider](https://downloads.khinsider.com/) - Video and PC game soundtracks for download in MP3 and lossless formats.
+- [Online Tone Generator](https://onlinetonegenerator.com/) - Generate tones, and you can also download them in WAV format.
+- [Tello Music Charts](https://music.tello.app/) - Find out the latest music charts of all countries in the world.
+- [Music Lab](https://musiclab.chromeexperiments.com/Experiments) - Learning music more accessible through fun, hands-on experiments.
+- [Rap4Ever](https://www.rap4ever.org/) - Explore rap songs, lyrics, mixtapes, albums, artists, and more.
+- [Every Noise](https://everynoise.com/) - Ongoing attempt at an algorithmically-generated scatter-plot of the musical genre-space.
+- [MP3Cut](https://mp3cut.net/) - Trim or cut any audio file online.
+- [MP3Gain](https://mp3gain.flowsoft7.com/) - Increase, decrease, and normalize the volume level of MP3 audio files (60M size limit per file).
+- [Magic Playlist](https://create.magicplaylist.co/#/?_k=m5jobg) - Type your favorite song and create the perfect playlist.
+- [Moises AI](https://moises.ai/) - Play with your favorite artists in any key, at any speed.
+- [Drumeo](https://www.drumeo.com/) - Learn to play the drums with the best teachers in the world.
+- [SoundLove](https://soundlove.se/) - Unusual synthesis algorithms to add a touch of randomness and unpredictability to music.
+- [Audionautix](https://audionautix.com/) - Music composed and produced by Jason Shaw, free for download and use (even for commercial purposes).
+- [Typatone](https://typatone.com/) - Generate your own music by typing on the keyboard.
+- [Incredibox](https://www.incredibox.com/) - Music app that lets you create your own music with the help of a merry crew of beatboxers.
+- [Sampurr](https://www.sampurr.com/) - Sample an audio from the web.
+- [Audiocheck](https://www.audiocheck.net/) - Test your audio equipment online.
+- [Mixlr](https://mixlr.com/) ($) - Share quality live audio online. Broadcast using any source, invite people to listen, and chat in real-time (Free for just listening).
+- [Learn Choral Music](https://www.learnchoralmusic.co.uk/) - John's Musical Instrument Digital Interface (MIDI) file collection of well-known choral works in voice-emphasized form, available for free downloading.
+- [Bandura Festival](https://bandura.ukrzen.in.ua/en#lvivbandurfest) - Online Bandura, a traditional Ukrainian instrument.
+- [AllMusic](https://www.allmusic.com/) - Provides comprehensive and in-depth information on albums, artists, songs, and bands, serving as a valuable resource for music enthusiasts.
+- [ASMR Microphones](https://asmrmicrophones.com) - Reviews, comparisons, and expert opinions on various ASMR microphones are provided to help users select the most suitable equipment.
+
+### Find Music
+
+- [Lalal.ai](https://www.lalal.ai/) - Extract vocal, accompaniment, and various instruments from any audio.
+- [Audd.io](https://audd.io/) - Recognize music or what's playing from sound or streams.
+- [Music-Map](https://www.music-map.com/) - Discover similar music based on your preferences.
+- [Commercial Tunage](https://www.commercialtunage.com/) - Identify songs featured in commercials.
+
+### Free Music
+
+- [Pretzel Rocks](https://www.pretzel.rocks/) - Stream-safe music for Twitch and YouTube.
+- [Incompetech](https://incompetech.com/) - Royalty-free music collection.
+- [Chosic](https://www.chosic.com/) - Free background music for both commercial and non-commercial use.
+
+### Mix Sounds
+
+- [Hidden Life Radio](https://hiddenliferadio.com/) - A livestream of music generated from tree biodata in Cambridge, Massachusetts.
+- [Noisli](https://www.noisli.com/) - Create and listen to background sounds to improve focus and productivity, or to relax and unwind.
+- [Soundrop](https://naim30.github.io/soundrop/) - An interactive music player where you can create beautiful patterns that generate music.
+- [SoundLove](https://www.producthunt.com/posts/soundlove) - A tool that helps you discover and create playlists based on your mood.
+- [Rainy Mood](https://rainymood.com/) - Enjoy the soothing sounds of rain for relaxation, sleep, and study.
+- [I Miss the Office](https://imisstheoffice.eu/) - An office noise generator providing the ambient sounds of modern office life to help recreate the office atmosphere while working from home.
+
+### Music Theory
+
+- [Teoria](https://www.teoria.com/)
+- [MusicTheory.net](https://www.musictheory.net/)
+- [All About Music Theory](https://www.allaboutmusictheory.com/) - Piano keyboard, Music notation, Major scale
+- [Studio Guru - Note Frequency Chart](https://studioguru.co/producer-tools/note-frequency-chart/)
+
+#### Rhyme
+
+- [RhymeZone](https://www.rhymezone.com/) - Find rhymes, synonyms, adjectives, and more.
+- [Rhymer](https://rhymer.com/) - Free online rhyming dictionary.
+
+### Spotify
+
+- [Chosic](https://www.chosic.com/spotify-playlist-analyzer/) - Discover new music by analyzing your playlists.
+- [Pudding](https://pudding.cool/2020/12/judge-my-spotify/) - A.I. trained to evaluate musical taste.
+- [Discoverify Music](https://www.discoverifymusic.com/login) - Discover new music in your taste.
+- [Spottr](https://spottr.vercel.app/login) - View your Spotify stats.
+- [Playlist Mutator](https://playlistmutator.com/) - Mutate existing playlists in React.
+- [TuneMyMusic](https://www.tunemymusic.com/) - Transfer playlists between music services.
+
+## Movies and Series
+
+- [Kanopy](https://www.kanopy.com/en/) (@) - Streaming platform offering thousands of films for free with library or university support.
+- [Movie Map](https://www.movie-map.com/) - Find similar movies based on your preferences.
+- [Reddit Movie Suggestions](https://www.reddit.com/r/MovieSuggestions/wiki/faq) - List of movie suggestions from various genres.
+- [A Good Movie to Watch](https://agoodmovietowatch.com/) - Handpicked, highly-rated movies and TV shows.
+- [Tubi TV](https://tubitv.com/home) - Free streaming service offering a wide range of movies and TV shows.
+- [Tiii.me](https://tiii.me/) - Calculate the total time you've spent watching TV shows.
+- [JustWatch](https://www.justwatch.com/) - Guiding platform for finding and streaming movies and TV shows.
+- [Movie Settings Database](https://www.moviesettingsdatabase.com/) - Organized collection of over 30,000 movies and TV shows by their settings.
+- [Reelgood Netflix Roulette](https://reelgood.com/roulette/netflix) - Randomly suggests a movie or TV show available on Netflix.
+- [Reelgood](https://reelgood.com/) - Browse, search, and watch TV shows and movies from over 150 services, including Netflix, Hulu, HBO, Disney+, Prime Video, and more.
+- [Movie Sounds](https://movie-sounds.org/) - Archive of free movie quotes featuring short sound clips and special effects.
+- [Tunefind](https://www.tunefind.com/) - Discover music from your favorite TV shows and movies.
+- [IMSDB](https://imsdb.com/) - Largest collection of movie scripts available on the web.
+- [Physics in Film and TV](https://physicsinfilmandtv.wordpress.com/) - Blog exploring the portrayal of physics concepts in films and television.
+- [RareFilm](https://rarefilm.net/) - Platform for rare and old films.
+- [I Have No TV](https://ihavenotv.com/) - Watch free online documentaries.
+- [WCostream](https://m.wcostream.com/) - Free cartoon and anime series streaming.
+- [Watch Documentaries](https://watchdocumentaries.com/) - Website offering a collection of documentaries on various topics.
+- [Senses of Cinema](https://www.sensesofcinema.com/) - One of the earliest online film journals, known for its professional, high-quality content related to film studies and industry trends.
+- [Chinese Drama Free](https://www.chinesedramafree.com/) - Chinese Dramas & Short TV Series Online Free to Watch
+
+### Anime
+
+- [Reddit Top Anime Streaming Sites](https://reddit.com/r/streamingAnime/wiki/topsites/) - Wiki page listing top anime streaming sites on Reddit.
+- [Reddit Legal Anime Streams](https://reddit.com/r/anime/wiki/legal_streams/) - Wiki page providing a list of legal anime streaming sites on Reddit.
+
+## Media
+
+- [Radio Garden](https://radio.garden/) - Explore live radio stations represented as green dots on a Google Earth map, allowing you to listen to any of them with just one click.
+- [Radiooooo](https://radiooooo.com/) - "The Musical Time Machine," where you can explore music from different times and places.
+- [Lightyear.fm](https://www.lightyear.fm/) - A representation of how far radio broadcasts have traveled from Earth at the speed of light.
+- [TasteDive](https://tastedive.com/) - Platform to discover music, books, movies, and more based on your preferences.
+- [PIDGI Wiki](https://www.pidgi.net/wiki/Main_Page) - Community-driven video game media database, including artwork, promotional materials, logos, and more.
+- [Kassellabs](https://kassellabs.io/) - Create your own texts on famous intros of movies and series.
+- [USTVGO](https://ustvgo.tv/) - Free live TV channels available online.
+- [All You Can Read](https://www.allyoucanread.com/) - The largest database of magazines and newspapers on the Internet, with listings for about 25,000 publications from all over the world.
+- [LexiCap](https://karpathy.ai/lexicap/) - Transcripts for Lex Fridman's podcast episodes.
+- [Brett Hall's TokCast Transcripts](https://www.aniketvartak.com/html/hall-index.html) - Transcripts for Brett Hall's TokCast podcast.
+- [Thumbly](https://thumbly.ai/) - Turn your script into attention-grabbing thumbnails that can increase your YouTube views.
+
+### X / Twitter
+
+- [TweetDeck](https://tweetdeck.twitter.com/) - Twitter dashboard application for the management of Twitter accounts, tracking, and organizing.
+- [Twitter Video Downloader](https://twittervideodownloader.com) - Online tool to download any Twitter video directly to your mobile or computer.
+- [ThreadReaderApp](https://threadreaderapp.com/) - Platform that helps you save Twitter threads as PDFs, making it easier to read and share them.
+- [Tweepsmap](https://tweepsmap.com/) - AI-driven Twitter analytics and management tool.
+- [Shadowban Checker](https://shadowban.yuzurisa.com/) - Tool to check whether a username is shadowbanned on Twitter.
+- [Twitter Name Generator](https://twitternamegenerator.com/) - Free online tool to generate pretty nicknames for Twitter.
+- [Thread Hunt](https://threadhunt.xyz/) - Platform for discovering quality Twitter threads.
+- [Small World](https://smallworld.kiwi/signin) - Utilizes the location from your Twitter profile to find nearby friends.
+- [Murmel](https://murmel.social/top) - Curates the latest thought-provoking stories from across the Twitterverse.
+- [Chirpty](https://chirpty.com/) - Create your own Twitter interaction circle.
+- [Capture My Tweet](https://capturemytweet.in/) - Turn your tweets into wonderful images for free.
+- [Twitter Card Generator](https://freecodetools.org/twitter-card-generator/) - Tool to generate Twitter cards, attaching rich content to Tweets for free.
+- [Rattibha](https://rattibha.com/) - Curates Twitter threads by categories and authors with time, language, and sorting options.
+- [Musk Messages](https://muskmessages.com/) - Platform compiling and categorizing direct messages from Elon Musk on Twitter, providing easy access to his thoughts and statements.
+
+### Reddit
+
+- [RedditList](https://redditlist.com/) - A comprehensive list of subreddits categorized by various topics.
+- [Redsim](https://anvaka.github.io/redsim/) - Find similar subreddits based on your interests.
+- [Reveddit](https://www.reveddit.com/about/) - Reveals Reddit's removed content. You can search by username, subreddit (r/), link, or domain.
+- [Spacebar Counter - Reddit List](https://www.spacebarcounter.net/reddit-list) - A collection of 100+ subreddits.
+- [Unreadit](https://unreadit.com/) - Reddit-fueled weekly newsletters that curate content from various subreddits.
+- [What Is This Thing](https://whatisthisthing.vercel.app/) - Aggregates posts and answers from the r/whatisthisthing subreddit.
+- [Gummy Search](https://gummysearch.com/) - Explore pain points, content ideas, and discover what people are eager to pay for on Reddit.
+- [RedditSearch.io](https://redditsearch.io/) - An advanced Reddit search engine that allows you to filter and customize your searches.
+- [Better Reddit Search](https://betterredditsearch.web.app/) - Enhance your Reddit search experience with improved features and functionality.
+
+### Discord
+
+- [Blobs](https://blobs.gg/) - Collection of over 4400 fun and playful custom emoji for Discord.
+
+## Economy
+
+- [Investopedia](https://www.investopedia.com/) - A source of financial education, news, and research for investors.
+- [Money](https://money.com/) - A comprehensive resource for personal finance and financial news.
+- [The Balance Money](https://www.thebalancemoney.com/) - Financial education and resources.
+- [CNN Fear and Greed Index](https://edition.cnn.com/markets/fear-and-greed) - Understand the current emotion driving the market.
+- [Where's Willy](https://www.whereswilly.com/) - An international non-profit volunteer project dedicated to tracking Canadian paper money around the world.
+- [Where's George](https://www.wheresgeorge.com/) - A project similar to "Where's Willy" for tracking American paper money globally.
+- [EuroBillTracker](https://en.eurobilltracker.com/) - An international non-profit volunteer project dedicated to tracking Euro notes around the world.
+- [TradingView](https://www.tradingview.com/) - A platform and social network used by over 30 million traders and investors worldwide to spot opportunities across global markets.
+- [LendingTree](https://www.lendingtree.com/) - A marketplace designed to save you money by finding loans rather than making them.
+- [Masterworks](https://www.masterworks.com/) - An exclusive community investing in blue-chip art.
+- [EquityBee](https://equitybee.com/) - Provides startup employees the funding they need to exercise their stock options by connecting them with a global network of investors.
+- [EquityZen](https://equityzen.com/) - Allows you to invest or sell shares in the secondary market with EquityZen funds.
+- [WTF Happened in 1971](https://wtfhappenedin1971.com/) - Website exploring and highlighting various economic, social, and financial events that occurred in the year 1971.
+- [Ergodicity Economics](https://ergodicityeconomics.com/) - Website providing insights into Ergodicity Economics and related concepts.
+
+## Business
+
+- [Crunchbase](https://www.crunchbase.com/) - A platform for discovering innovative companies, startups, and key individuals in the business world. Provides comprehensive data and insights about companies, investments, and industry trends.
+- [Business Model Toolbox](https://bmtoolbox.net/) - A resource to learn about various business concepts and models.
+- [Gumroad](https://gumroad.com/) - E-commerce platform for creators to sell digital products directly to customers.
+- [Humble Bundle](https://www.humblebundle.com/) - Platform selling games, ebooks, software, and digital content with a mission to support charity while providing great content at affordable prices.
+- [Google Takeout](https://takeout.google.com/) - Export a copy of all your Google data.
+- [Honey](https://www.joinhoney.com/) - A browser extension that automatically searches for coupons on over 30,000 sites globally.
+- [BotHelp](https://bothelp.io/widget) - Provides a free chat button widget for websites.
+- [CertificateClaim](https://www.certificateclaim.com/) - A digital service for creating and sending various types of certificates.
+- [Respresso](https://respresso.io/) ($) - A tool to manage your app’s localization texts, images, colors, fonts, and more, delivering them automatically into your projects with a single click.
+- [Bonanza](https://www.bonanza.com/) - An online marketplace that empowers entrepreneurs to build a sustainable business based on repeat customers.
+- [Pipl](https://pipl.com/) - Identify, search, and verify employees using email addresses, social usernames, or phone numbers by searching through Pipl's global index of identity information, reducing customer friction, fighting fraud, and saving time on review and research.
+
+### Finance
+
+- [FIGR](https://www.figr.app/) - Google Docs + Calculator = Personal finances
+- [LiveFortunately](https://app.livefortunately.com/) - Plan for a better financial future. Create a complete financial plan to make the most of your money.
+- [KeeperTax](https://www.keepertax.com/ask-an-ai-accountant-2-0) - AI Accountant for getting help and calculating tax-related questions.
+
+### Patents
+
+- [Espacenet](https://worldwide.espacenet.com/) - Free access to over 130 million patent documents.
+- [Google Patents](https://patents.google.com/) - Search and read the full text of patents from around the world.
+- [WIPO Patentscope](https://patentscope.wipo.int/search/en/search.jsf) - Search 105 million patent documents, including 4.3 million published international patent applications (PCT).
+- [Patently Apple](https://www.patentlyapple.com/patents-applications/) - Explore patent applications made by Apple.
+- [USPTO Report](https://uspto.report/) - Platform providing information and reports related to patents from the United States Patent and Trademark Office.
+
+### Trends
+
+- [Google Trends](https://trends.google.com/trends/?geo=US) - Explore trending topics and insights based on Google searches.
+- [Google Trends - Visualize](https://trends.google.com/trends/hottrends/visualize) - Visualize and explore the hottest trends on Google.
+- [Statista](https://www.statista.com/) - A platform for statistical data and visualizations, providing insights into various industries and topics.
+- [Google Books Ngram Viewer](https://books.google.com/ngrams) - Graphically visualize the occurrence of phrases in a corpus of books over selected years.
+
+### Meetings
+
+- [When2meet](https://www.when2meet.com/) - A free service for scheduling group meetings. It allows users to create and participate in availability surveys to find the best time for a group to meet.
+- [Sessions](https://sessions.us/) - A web-based conferencing tool designed to enhance meetings. It aims to improve the overall meeting experience and is available for free.
+- [Form to Chatbot](https://formtochatbot.com/) - Convert Google forms into interactive conversations in the form of chatbots. This tool helps in creating engaging and dynamic interactions based on form responses.
+
+## Jobs
+
+- [Y Combinator Jobs](https://www.ycombinator.com/jobs) - Discover the best startup jobs curated by Y Combinator.
+- [Coroflot](https://www.coroflot.com/discover) - Job search platform specifically tailored for designers.
+- [Cool Startup Jobs](https://www.coolstartupjobs.com/) - Explore job opportunities in growing startups and give your stock options a chance.
+- [Anon Friendly](https://anonfriendly.com/) - Find jobs that respect your desire for anonymity.
+- [Prompt Engineering Jobs](https://prompt-engineering-jobs.com) - Explore engineering job opportunities with Prompt.
+- [KeyValues](https://www.keyvalues.com/) - Find engineering teams that align with your values.
+- [About.me](https://about.me/) - Platform for freelancers and entrepreneurs to grow their audience and attract clients.
+- [Rejected.us](https://rejected.us/) - Read and share stories of job rejections.
+- [Tech Interview Handbook](https://www.techinterviewhandbook.org/) - Free curated interview preparation materials.
+
+### Remote Jobs
+
+- [Remote OK](https://remoteok.com/) - Job board for remote positions.
+- [Remotive](https://remotive.com/) - Platform connecting remote companies with talented professionals.
+- [Remote.co](https://remote.co/) - Resource for finding remote work opportunities.
+- [Remote Leaf](https://remoteleaf.com/) - Job board focusing on remote opportunities in the tech industry.
+- [Remote Leads](https://remoteleads.io/) - Platform connecting companies with remote leads in the software development field.
+- [RemoteBear](https://remotebear.io/) - Job board for remote positions in tech and design.
+- [RemoteBase](https://remotebase.com/) - Platform connecting remote workers with companies offering remote positions.
+- [JustRemote](https://justremote.co/) - Job board for remote work opportunities.
+- [JS Remotely](https://jsremotely.com/) - Job board specifically for remote JavaScript positions.
+- [Jobspresso](https://jobspresso.co/) - Curated job board for remote work in tech, marketing, and more.
+- [Just Join](https://justjoin.it/) - Job board for remote positions in IT.
+- [FlexJobs](https://flexjobs.com/) - Job board for flexible and remote work opportunities.
+- [We Work Remotely](https://weworkremotely.com/) - Job board for remote positions in various industries.
+- [Daily Remote](https://dailyremote.com/) - Daily updated job board for remote work opportunities.
+- [AngelList Candidates](https://angel.co/candidates/overview) - Platform connecting startups with potential candidates, including remote positions.
+- [Hired](https://hired.com/) - Platform connecting tech talent with innovative companies.
+- [PowerToFly](https://powertofly.com/) - Job board focusing on remote opportunities for women in tech.
+- [SkipTheDrive](https://skipthedrive.com/) - Job board for remote positions in various industries.
+- [Authentic Jobs](https://authenticjobs.com/) - Job board for creative and tech professionals, including remote positions.
+- [Working Nomads](https://workingnomads.co/) - Job board for remote positions in various industries.
+- [Europe Remotely](https://europeremotely.com/) - Job board for remote positions specifically in Europe.
+- [Virtual Vocations](https://virtualvocations.com/) - Job board for telecommute and remote positions.
+- [Benture.IO](https://benture.io) - Job board for remote opportunities in AI training roles.
+
+### Freelancing
+
+- [Remote Starter Kit](https://www.remotestarterkit.com/) - The ultimate list of tools and processes for remote teams.
+- [Fiverr](https://www.fiverr.com/) - Find the perfect freelance services for your business.
+- [Upwork](https://www.upwork.com/) - Hire freelancers and get freelancers jobs online.
+
+### Portfolio / CV / Resume
+
+- [University of Nebraska Omaha - Job & Internship Resources](https://www.unomaha.edu/student-life/achievement/academic-and-career-development-center/career-development/jobs-and-internships/job-internship-resources.php) - Résumé and Cover Letter Resources provided by the Academic and Career Development Center at the University of Nebraska Omaha.
+- [VisualCV](https://www.visualcv.com/resume-samples/) - Collection of 500+ professional resume examples.
+- [SuperPortfolio](https://superportfolio.co/) - Online Portfolio Maker.
+- [Referd.ai](https://www.referd.ai/resume-scanner) - Free resume scanner.
+- [RxResu.me](https://rxresu.me/) - Free and open-source resume builder.
+- [GoodCV](https://www.goodcv.com/) - Create a professional Resume/CV in minutes without Photoshop or AI techniques.
+- [JSON Resume](https://jsonresume.io/) - Upload your JSON resume according to the spec and have it rendered beautifully.
+- [CVmkr](https://cvmkr.com/) - Create, maintain, publish, and share your CVs for free.
+- [Novoresume](https://novoresume.com/) - Online resume builder.
+- [HelloTechRecruiters](https://hellotechrecruiters.com/) - Tailored for tech recruiters.
+- [FlowCV](https://flowcv.com/) - AI-boosted resume builder, cover letter, job tracker, email signature, personal website.
+- [Signature Maker](https://signature-maker.net/) - Create handwritten digital signatures.
+
+### Careers
+
+- [Roadmap.sh](https://roadmap.sh/) - Provides roadmaps for various development areas.
+- [WTF Should I Do With My Life](https://www.wtfshouldidowithmylife.com/) - A resource to explore and learn about different occupations.
+- [path-to-polymath.notion](https://path-to-polymathy.notion.site/path-to-polymathy/Path-To-Polymathy-d7586429b7ce4db1889fc539822b9670) - Arrangement of every discipline and field out there, and what specific topics make them up.
+
+## Startups
+
+- [Startup Growth Calculator](https://growth.tlb.org/) - Calculate how much funding your startup needs for growth.
+- [Startup Equity Calculator](https://capbase.com/startup-equity-calculator/) - Split equity based on different variables for your startup.
+- [Fifty Years Progress Map](https://progress.fiftyyears.com/) - Highlights large markets with low startup investment. Provides a list of massive markets ranked by competitiveness, including market size and total investment in Series A startups over the last 10 years. Calculates a Competition Ratio for each market.
+- [Museum of Websites](https://www.kapwing.com/museum-of-websites) - A gallery showcasing how famous internet companies have changed over time.
+- [Goal Examples](https://hypercontext.com/goal-examples) - A curated list of goal examples for every role in tech.
+- [Startup Resources](https://www.feedough.com/startup-resources/) - A collection of resources categorized for startups.
+- [500+ Free Tools For Startups](https://docs.google.com/spreadsheets/d/1s6-hGBh0_tqa-jd23fsdYuwbmS8UPmElPqaH-Rnoa_A/htmlview) - A comprehensive list of free tools for startups.
+- [Founder Resources](https://www.founderresources.io/) - Free curated resources, templates, and tools for startups.
+- [100+ Resources on GPT-3](https://harishgarg.gumroad.com/l/wiSvc?ref=producthunt) - A curated list of 100+ resources on GPT-3.
+- [100+ Resources for Building a Successful Startup](https://cerdeira.notion.site/b3b5f44d37cf4843b3fcd2f300354467?v=8f3458522f4542d8896ebb3720c14b2d) - A compilation of resources for building a successful startup.
+- [2,500 Accelerators Incubators](https://view.officeapps.live.com/op/view.aspx?src=https%3A%2F%2Fattachments.convertkitcdnn2.com%2F587796%2F16ab0442-1232-4a49-956c-acafd6df4189%2F2%2C500%2520Accelerators%2520Incubators.xlsx&wdOrigin=BROWSELINK) - A list of 2,500 accelerators and incubators.
+- [The Complete Unicorn List](https://view.officeapps.live.com/op/view.aspx?src=https%3A%2F%2Fattachments.convertkitcdnn2.com%2F587796%2F476863f4-bda0-4132-8bd0-d25728513cfd%2FThe%2520Complete%2520Unicorn%2520List.xlsx&wdOrigin=BROWSELINK) - A comprehensive list of 1,016 unicorns (private companies valued +$1B).
+- [GitHub Email Hunter](https://chrome.google.com/webstore/detail/github-email-hunter/ppcegaekdbgcgbapfdcjbhednhmgcjnk) - Find email addresses for GitHub users & repos with one click.
+- [The Angel Philosopher](https://theangelphilosopher.com/) - Compilation of Naval's wisdom, knowledge, and thoughts.
+- [Under Glass](https://underglass.io/) - Analysis of the world's best digital products.
+- [The Perfect Pitch Deck](https://attachments.convertkitcdnn2.com/587796/1e723803-ab50-4a61-9b3a-f347aa436408/The%20Perfect%20Pitch%20Deck.pdf) - Lessons from analyzing 350+ startup pitch decks.
+- [Old Computers Museum](https://oldcomputers.net/) - Explore a museum of old and vintage computers with 150 exhibits.
+- [Startups List](https://www.startups-list.com/) - Collections of the best startups in different places.
+- [Pessimists Archive](https://pessimistsarchive.org/) - Project that jogs our collective memories about the hysteria, technophobia and moral panic that often greets new technologies, ideas and trends.
+
+### Failures
+
+- [Failory - Google Failures](https://www.failory.com/google/) - Learn from Google's +100 failures to build profitable businesses and scale acquired companies.
+- [Killed by Google](https://killedbygoogle.com/) - Projects that Google launched and ended.
+
+### Finding Ideas
+
+- [Random Startup Website Generator](https://tiffzhang.com/startup/) - A random startup website generator.
+- [AnswerSocrates](https://answersocrates.com/) - Discover the questions people are asking on Google about almost any topic, for free.
+- [IdeasAI](https://ideasai.com/) - Ideas that are generated by OpenAI's GPT-3.
+- [AnswerThePublic](https://answerthepublic.com/) - Discover what people are asking about in popular search engines.
+- [List of Emerging Technologies](https://en.wikipedia.org/wiki/List_of_emerging_technologies) - Wikipedia's list of emerging technologies.
+- [UniCorner](https://unicorner.news/) - Newsletter that delivers a 2-minute rundown of an up-and-coming startup to your inbox every Monday morning.
+- [DemandHunt](https://demandhunt.com/) ($) - Platform for discovering and upvoting new startups.
+
+### Connectivity
+
+- [Integromat](https://www.integromat.com/en?pc=referralbonus) - Connect apps and automate workflows in a few clicks.
+- [IFTTT](https://ifttt.com/) - Automate your favorite apps and devices quickly and easily, making them work together in new and powerful ways.
+- [Franz](https://meetfranz.com/) - Manage all your messaging apps like WhatsApp, Facebook Messenger, Slack, Telegram, and more in one platform.
+- [Google Remote Desktop](https://remotedesktop.google.com/) - Remotely connect with your home or work computer, or share your screen with others.
+- [RecWide](https://www.recwide.com/) - Screen and webcam recorder. Free, online (No download required).
+- [1,000 True Fans](https://kk.org/thetechnium/1000-true-fans/) - The concept of cultivating 1,000 true fans for sustainable creative success.
+- [Alias](https://alias.co/) - Stay up to date with the best of the bests.
+- [LittleSis](https://littlesis.org/) - Free database of who-knows-who at the heights of business and government.
+
+### Design
+
+- [Social Image Maker](https://socialimagemaker.io/) - Tool for creating social media images with ease.
+- [Open Source Design Resources](https://opensourcedesign.net/resources/) - Showcase of websites and platforms offering openly licensed icons, fonts, images, tools, and other resources for design purposes.
+- [Transparent Textures](https://transparenttextures.com/) - Platform providing transparent textures for use in design projects.
+- [Collection of $0 Design Tools](https://www.producthunt.com/e/0-design-tools) - A collection of free design tools to aid in project creation.
+- [Easel.ly](https://www.easel.ly/) - Design tool for visualizing various types of information.
+- [Material Design](https://m3.material.io/) - Design system by Google for building high-quality digital experiences for Android, iOS, Flutter, and the web.
+- [Rasterizer.io](https://rasterizer.io/) - Tool for creating dynamic images.
+- [Jitter.Video](https://jitter.video/) ($) - A simple animation tool on the web.
+- [Polotno Studio](https://studio.polotno.com/) - Web application for creating graphical designs without sign-ups and ads, a free alternative to Canva.
+- [BitBof](https://bitbof.com/) - Free painting and sketching apps.
+- [Sumo](https://sumo.app/) - Drawing tool and image editor.
+- [Random Design Stuff](https://randomdesignstuff.com/) - Browse handpicked websites for designers, both useful and unuseful.
+- [Discover NFT Club](https://www.discovernft.club/) - Discover the latest NFT projects.
+- [Haikei](https://app.haikei.app/) - Web-based design tool to generate unique SVG design assets for various purposes.
+- [Spline](https://spline.design/) - Create 3D scenes, edit materials, and model 3D objects, giving control over the outcome of design work.
+- [Visiwig](https://www.visiwig.com/) - Create graphics just by clicking and pasting.
+- [FreeType](https://freetype.org/) - Software library written in C for rendering fonts, capable of producing high-quality output of most vector and bitmap font formats, designed to be small, efficient, highly customizable, and portable.
+
+#### Colors
+
+- [HexColor](https://hexcolor.co/) - Offers various free color tools.
+- [Adobe Color Wheel](https://color.adobe.com/create/color-wheel) - A color wheel that can be used to generate color palettes.
+- [SchemeColor](https://www.schemecolor.com/) - Allows you to download color schemes.
+- [Mobile Palette Generator](https://mobilepalette.colorion.co/) - A tool for generating mobile palettes.
+- [DeGraeve Color Palette Generator](https://www.degraeve.com/color-palette/) - Generates color palettes.
+- [0to255](https://0to255.com/) - A color tool that helps find lighter and darker colors based on any color.
+- [ColorHexa](https://www.colorhexa.com/) - Provides information about any color and generates matching color palettes.
+- [Color Hunt](https://colorhunt.co/) - Discover hand-picked color palettes.
+- [Coolors](https://coolors.co/) - Color scheme generator and palette creation tool, allowing users to explore, create, and share color combinations for design projects.
+- [Colors.lol](https://colors.lol/) - Website offering a simple interface for generating color palettes, with options for saving and exporting them for use in digital design.
+
+#### Fonts
+
+- [Font Squirrel](https://www.fontsquirrel.com/) - Free Font Utopia.
+- [Font Discovery](https://fontdiscovery.typogram.co/) - Weekly design, font, and color creativity newsletter for creators, founders, makers.
+- [MyFonts](https://www.myfonts.com/) - Over 130,000 available fonts, and counting.
+- [Google Fonts](https://fonts.google.com/) - Collection of free and open-source fonts by Google.
+- [DaFont](https://www.dafont.com/) - A popular website offering free fonts for download, with categories for various styles and uses, including decorative, script, and sans-serif fonts.
+- [UCL Fonts Project](http://vecg.cs.ucl.ac.uk/Projects/projects_fonts/projects_fonts.html) - A research project focused on manifold of fonts, providing findings of their work and an interactive 2D Font Manifold Demonstration.
+
+#### Icons / Icon Packs
+
+- [The Noun Project](https://thenounproject.com/) - Platform offering a vast collection of free icons and stock photos, available for use in a wide range of projects and designs.
+- [IconPacks](https://www.iconpacks.net/) - Platform offering a variety of icon packs for personal and commercial use.
+- [Doodlicons on Notion](https://www.notion.so/Doodlicons-519314a92ed3474093a10e44946bbb72) - Doodle icons for project wireframes on Notion.
+- [Illustration Kit](https://illustrationkit.com/) - Collection of free vector illustrations for personal and commercial projects.
+- [FontAwesome](https://fontawesome.com/) - Internet's icon library and toolkit, widely used by designers, developers, and content creators.
+- [Iconshock](https://www.iconshock.com/freeicons/) - Platform offering icons from various open-source collections, with 100k icons available for free download.
+- [3DIcons](https://3dicons.co/) - Collection of 3D icons available for free commercial and personal use under CC0 license.
+- [Fontello](https://fontello.com/) - Icon fonts generator for creating custom icon fonts.
+- [HealthIcons](https://healthicons.org/) - Free and open-source health icons for various use cases.
+- [TablerIcons](https://tablericons.com/) - Open-source free SVG icons, highly customizable, and no attribution required for commercial use.
+- [David Li](https://david.li/) - Platform for particle-based 3D simulations and renderings.
+- [IcoMoon](https://icomoon.io/) - Platform for creating and managing icon fonts.
+- [UTF8Icons](https://www.utf8icons.com/) - Collection of unicode symbols that are part of the utf-8 standard.
+- [Free Isometric Illustrations](https://passionhacks.com/free-isometric-illustrations/) - Collection of free isometric illustrations for various projects.
+- [Illlustrations](https://illlustrations.co/) - Open-source illustrations kit for creative projects.
+- [PixelBazaar](https://www.pixelbazaar.com) - Opinionated icons for brands with character.
+- [Iconfinder](https://www.iconfinder.com/) ($) - Platform offering icons, illustrations, 3D illustrations, designers, and free icons.
+- [Iconz Design](https://iconz.design/) ($) - Premium 3D library of 223 icons.
+- [HugeIcons.pro](https://hugeicons.pro/) ($) - Platform offering over 25,000 icons in 5 unique styles, organized across 57 popular categories.
+
+#### Stock Images
+
+- [The Stocks](https://thestocks.im/) - Aggregator providing access to free stock photos, videos, and music from various sources.
+- [Pexels](https://www.pexels.com/) - Platform offering high-quality stock photos and videos available for free download and use.
+- [Unsplash](https://unsplash.com/) - Website providing a large collection of high-resolution, royalty-free images for creative projects.
+- [FreeImages](https://www.freeimages.com/) - Platform offering a diverse collection of free stock photos for personal or commercial use.
+- [Pixabay](https://pixabay.com/) - Community-driven platform with high-quality stock images, videos, and music shared by contributors.
+- [PNG Guru](https://www.pngguru.in/) - Source for free PNG images, backgrounds, and templates.
+- [Pond5](https://www.pond5.com/free) - Platform offering free stock videos, photos, and music resources.
+- [Critter Pics](https://www.critter.pics/) - Collection of critter pictures for creative projects.
+- [Stock Up](https://stockup.sitebuilderreport.com/) - Indexing 35,356 photos from 31 different free stock photo websites for easy access.
+- [Shutterstock](https://www.shutterstock.com/) - Platform providing a vast library of royalty-free images, videos, vectors, illustrations, and music.
+- [Zoom.nl](https://zoom.nl/) - Largest photography community in the Netherlands, offering resources and a platform for photography enthusiasts.
+- [Depositphotos](https://depositphotos.com/) - Platform with 232 million files, including royalty-free images, videos, vectors, illustrations, and music.
+- [Skuawk](https://skuawk.com/) - Source of public domain photos for various creative projects.
+- [All-Free-Download](https://all-free-download.com/) - Platform offering graphics art available for free use in personal or commercial projects.
+
+#### Wallpapers
+
+- [Wallpapers.com](https://wallpapers.com/) - Website providing a variety of wallpapers for different themes and styles.
+- [WallpaperCave](https://wallpapercave.com/) - Platform offering a collection of high-quality wallpapers across various categories.
+- [Wallhaven](https://wallhaven.cc/) - Wallpaper community with a vast collection of high-resolution wallpapers.
+- [MovieMania](https://www.moviemania.io/phone) - Database of textless high-resolution movie wallpapers for phones.
+- [WallpaperTip](https://www.wallpapertip.com/) - Platform for uploading and discovering free HD wallpapers.
+- [SimpleDesktops](https://simpledesktops.com/browse/) - Collection of minimal wallpapers for desktop backgrounds.
+- [WallpaperFlare](https://www.wallpaperflare.com/search?wallpaper=vertical) - Website offering high-resolution vertical wallpapers.
+- [Positron Dream](https://www.positrondream.com/wallpapers-all) - Collection of abstract wallpapers available for download.
+- [KPopDemonHuntersWallpaper](https://kpopdemonhunterswallpaper.com/) - KPop Demon Hunters Wallpaper - Free HD Wallpapers Download.
+
+## Art
+
+- [WeavesSilk](https://weavesilk.com/) - Create beautiful flowing art with Silk.
+- [Google Arts & Culture](https://artsandculture.google.com/) - A platform bringing the world’s art and culture online for everyone.
+- [ArtGraphica](https://www.artgraphica.net/) - A resource for free drawing, sketching, and painting techniques.
+- [Tattoos Wizard](https://tattooswizard.com/) - Find tattoo artists and studios near you.
+- [The Art Institute of Chicago Collection](https://www.artic.edu/collection) - Explore thousands of artworks in the museum’s collection.
+- [ZoomQuilt](https://zoomquilt.org/) - Collaborative infinitely zooming painting.
+- [Invaluable](https://www.invaluable.com/) - The world's premier online auctions platform, featuring thousands of items added daily. Invaluable provides accessibility to discovering and acquiring exceptional art and objects anytime, anywhere.
+- [50 Watts](https://50watts.com/) - Archive of weird and wonderful visual ephemera from around the world
+
+### Photography
+
+- [Cambridge in Colour](https://www.cambridgeincolour.com/) - Learning community for photographers
+- [Exposure Guide](https://www.exposureguide.com/) - Photography Tips, Techniques, and Tutorials
+
+### Art Communities
+
+- [Ello](https://ello.co/discover)
+- [Behance](https://www.behance.net/)
+- [ArtStation](https://www.artstation.com/)
+
+## Academia
+
+- [TLDR This](https://tldrthis.com/) - Platform to summarize any piece of text into concise, easy-to-digest content, helping users overcome information overload.
+- [Archive.org General Index](https://archive.org/details/GeneralIndex) - General index providing access to over 107 million journal articles.
+- [Homework Help Global](https://www.homeworkhelpglobal.com/) - Online platform offering professional and custom essay writing services.
+- [Dartmouth Academic Careers](https://sites.dartmouth.edu/nyhan/academic-careers/) - Resource providing insights into academic careers.
+- [CNX](https://cnx.org/) - Platform to view and share free educational materials.
+- [Reach Out Michigan Tutorials](https://www.reachoutmichigan.org/learn/tutorials.html#math) - Collection of online tutorials and references covering various topics.
+- [Open Text BC](https://opentextbc.ca/) - Simple book production software allowing users to publish textbooks, scholarly monographs, syllabi, fiction and non-fiction books, white papers, and more in multiple formats.
+- [Modern for Wikipedia](https://chrome.google.com/webstore/detail/modern-for-wikipedia/emdkdnnopdnajipoapepbeeiemahbjcn) - Chrome extension enhancing the Wikipedia experience with a modern and customizable design.
+- [Wikiwand - Wikipedia Modern](https://chrome.google.com/webstore/detail/wikiwand-wikipedia-modern/emffkefkbkpkgpdeeooapgaicgmcbolj) - Chrome extension optimizing Wikipedia's content for an improved reading experience.
+- [List of Academic Databases and Search Engines](https://en.wikipedia.org/wiki/List_of_academic_databases_and_search_engines) - Wikipedia page listing academic databases and search engines.
+- [Scribbr APA Citation Generator](https://www.scribbr.com/citation/generator/apa/) - Platform providing accurate APA citations, verified by experts and trusted by millions.
+- [Bridges: About Institutions, Histories, and Artifacts](https://temple.manifoldapp.org/projects/bridges) - Resource about institutions, histories, and artifacts of United States college and university life.
+- [Tropy](https://tropy.org/) - Platform to organize research by turning photos into items.
+- [Linda Hall Library Catalog](https://catalog.lindahall.org/discovery/search?vid=01LINDAHALL_INST:LHL) - Catalog of the Linda Hall Library that allows you to search for books, journals, conference proceedings, technical reports and standards, and other materials, focusing on science, engineering, and technology.
+- [Project Abstracts](https://projectabstracts.com/) - Collection of project abstracts and downloads for academic mini projects and final year projects across various fields.
+- [SCIRP Open Access Journal](https://www.scirp.org/journal/OpenAccess) - Platform offering open-access academic journals across various scientific disciplines, promoting free access to research.
+- [DOI.org](https://www.doi.org/) - The official website for Digital Object Identifiers (DOI), providing a system for the persistent identification and access of digital resources, including academic papers and datasets.
+
+### Studying
+
+- [Bartleby](https://www.bartleby.com/) - A platform to search for textbooks, step-by-step explanations to homework questions, and more.
+- [Chegg](https://www.chegg.com/) ($) - A service offering 24/7 course help, including textbook solutions and expert Q&A.
+- [Chegg Flashcards](https://www.chegg.com/flashcards) (@) - Study with flashcards created by students and experts for various courses.
+
+### Calculators
+
+- [Calc Resource](https://calcresource.com/index.html) - Platform offering a variety of calculators and resources for mathematical calculations.
+- [eFunda](https://www.efunda.com/home.cfm) - Website providing calculators, formulas, and information on materials and processes.
+- [LCM Calculator](https://www.calculator.net/lcm-calculator.html) - Calculator for finding the Least Common Multiple.
+- [GCF Calculator](https://www.calculator.net/gcf-calculator.html?numberinputs=9%2C+57%2C+72&x=75&y=22) - Calculator for finding the Greatest Common Factor.
+- [CalculatorSoup](https://www.calculatorsoup.com/) - Online platform offering a variety of calculators for different mathematical purposes.
+- [RapidTables](https://www.rapidtables.com/) - Website providing a collection of calculators and tables for quick reference.
+- [Linear Algebra Calculator](https://www.emathhelp.net/en/linear-algebra-calculator/?u=3%2C1%2C4&v=-2%2C0%2C5&action=cross+product) - Calculator for linear algebra calculations, such as cross product.
+- [Wikipedia: List of Physical Quantities](https://en.wikipedia.org/wiki/List_of_physical_quantities) - Wikipedia page listing various physical quantities.
+- [eMathHelp Linear Algebra Calculator](https://www.emathhelp.net/en/calculators/linear-algebra/) - Online calculator for linear algebra calculations.
+- [Online Math School](https://onlinemschool.com/math/assistance/) - Platform providing math assistance with various calculators and resources.
+- [Percentage Calculator](https://www.percentofpercentcalculator.com) - A simple, interactive tool for calculating percentages quickly and accurately.
+
+### MOOC (Massive Open Online Courses)
+
+- [InfoCobuild - Audio Video Courses](http://www.infocobuild.com/education/audio-video-courses/) - Collection of free audio/video lectures for academic courses from colleges and universities around the world. It is well-categorized with academic subjects including biology, chemistry, computer science, economics, electronics and electrical engineering, history, literature, materials science, mathematics, physics, and psychology.
+- [MIT OpenCourseWare](https://ocw.mit.edu/) - MIT's initiative offering free and open access to a wide range of course materials.
+- [Coursera](https://www.coursera.org/) - Online learning platform providing courses, certificates, and degree programs from universities and organizations worldwide.
+- [Wikiversity](https://en.wikiversity.org/wiki/Wikiversity:Main_Page) - Wikimedia Foundation project providing free educational content and resources.
+- [Udemy](https://www.udemy.com/) - Platform offering a vast array of online courses on various subjects, taught by experts.
+- [Open Culture](https://www.openculture.com/) - Website providing free cultural and educational media, including courses, textbooks, and audiobooks.
+- [edX](https://www.edx.org/) - Online learning platform offering courses, certificates, and degrees from universities and institutions around the world.
+- [Udacity](https://www.udacity.com/) - Platform specializing in tech-related courses and nanodegree programs designed in collaboration with industry leaders.
+- [Stanford Online](https://online.stanford.edu/) - Stanford University's platform for online learning, offering a variety of courses and programs.
+- [OpenLearn](https://www.open.edu/openlearn/) - The Open University's initiative providing free access to course materials and educational resources.
+- [Open Learning Initiative (OLI)](https://oli.cmu.edu/) - Carnegie Mellon University's platform offering openly available courses and resources.
+- [MITx](https://www.mitx.org/) - MIT's platform providing online courses and programs with a focus on cutting-edge research.
+- [Open Yale Courses](https://oyc.yale.edu/) - Yale University's initiative providing free access to introductory courses taught by distinguished faculty.
+- [Alison](https://alison.com/) - Platform offering free online courses and diplomas across a range of subjects.
+- [Academic Earth](https://academicearth.org/) - Website aggregating online courses from top universities worldwide.
+- [NPTEL](https://nptel.ac.in/) - National Programme on Technology Enhanced Learning, providing online courses in engineering and science.
+- [University of the People](https://www.uopeople.edu/) - Online university offering tuition-free, accredited degree programs.
+- [Canvas Network](https://www.canvas.net/) - Platform offering online courses and programs from various institutions using the Canvas learning management system.
+- [Isaac Newton Institute for Mathematical Sciences](https://www.newton.ac.uk/) - Institute's website providing access to mathematical science resources and programs.
+- [Saylor Academy](https://www.saylor.org/) - Nonprofit initiative offering free, self-paced online courses.
+- [Connexions](https://cnx.org/) - Platform providing open educational resources and textbooks in various subject areas.
+- [Directory of Open Access Journals (DOAJ)](https://doaj.org/) - Online directory providing access to high-quality, open-access scientific and scholarly journals.
+- [Learning on the Internet](https://www.learningontheinternet.com/?ref=producthunt) - Platform featuring curated educational content and resources from various sources.
+- [Class Central](https://www.classcentral.com/) - Search engine and reviews platform for online courses, aggregating courses from various providers.
+- [OCW SNU](https://ocw.snu.ac.kr/) - Open CourseWare from Seoul National University.
+
+## Science
+
+- [Reproducibility Institute](https://reproducibilityinstitute.org/w/) - Projects that provide academic papers, cheatsheets, and torrents for paid courses.
+- [EBSCO](https://www.ebsco.com/) - Provider of research databases, e-journals, magazine subscriptions, ebooks, and discovery service.
+- [Zooniverse](https://www.zooniverse.org/) - Participate in real research with over 50 active online citizen science projects.
+- [Experiment](https://experiment.com/) - Help fund the next wave of scientific research.
+- [Closer to Truth](https://www.closertotruth.com/) - Robert Lawrence Kuhn explores the fundamental questions of the universe.
+- [Nature Scitable](https://www.nature.com/scitable/) - Library of scientific overviews. Customize your own eBooks, create an online classroom, contribute and share content, and connect with networks of colleagues.
+- [Vinaire](https://vinaire.me/) - Physics and Math classes.
+- [VisualPDE](https://visualpde.com/) - Interactive platform for exploring science and mathematics, offering simulations on topics like waves, viruses, and reaction-diffusion patterns.
+- [Whole Earth](https://wholeearth.info/) - Nearly-complete archive of Whole Earth publications, a series of journals and magazines published by Stewart Brand and the POINT Foundation from 1968 to 2002, made available for scholarship, education, and research purposes.
+- [Sketchplanations](https://sketchplanations.com/categories/science) - Collection of simple sketches and visual explanations on scientific concepts, aimed at making complex topics more accessible.
+
+### Biographies
+
+- [Mathematics History](https://mathshistory.st-andrews.ac.uk/) - Free online resource containing biographies of more than 3000 mathematicians and over 2000 pages of essays and supporting materials.
+- [Web of Stories](https://www.webofstories.com/) - Listen to life stories of some of the greatest people of our time.
+- [Letters of Note](https://lettersofnote.com/) - History’s most fascinating letters.
+- [Organism Earth Library](https://www.organism.earth/library/).
+- [Darwin Project](https://www.darwinproject.ac.uk/) - Letters written by the evolutionary scientist, Charles Darwin (1809–1882).
+- [Darwin Online](https://darwin-online.org.uk/) - The world's largest and most widely used resource on Charles Darwin.
+- [Newton Project](https://www.newtonproject.ox.ac.uk/) - Online edition of all of Sir Isaac Newton’s (1642–1727) writings.
+- [Bethe](https://bethe.cornell.edu/index.html) - Personal and historical perspectives of Hans Bethe.
+- [Open Source Shakespeare](https://www.opensourceshakespeare.org/) - Open source Shakespeare.
+- [Leonardo da Vinci](https://www.leonardodavinci.net/) - Leonardo da Vinci, his life, and artworks.
+- [Our Karl Popper](https://ourkarlpopper.net/) - How Karl Popper has made a difference in our lives (Testimonies from the five continents).
+- [Varlam Shalamov](https://shalamov.ru/en/) - Writings and historical background of Varlam Shalamov, a Russian writer known for his series of short stories about imprisonment in Soviet labor camps.
+- [Samuel Beckett On-Line Resources](https://www.samuel-beckett.net/) - The Samuel Beckett On-Line Resources and Links Pages. (Samuel Beckett's [Waiting for Godot](https://www.samuel-beckett.net/Waiting_for_Godot_Part1.html))
+- [Philip K. Dick](https://philipdick.com/) - Devoted to the life and work of Science Fiction writer Philip K. Dick (1928-82).
+- [Alan Turing Digital Archive](https://turingarchive.kings.cam.ac.uk/) - This digital archive contains many of Turing's letters, transcriptions of talks, photographs, and unpublished papers.
+- [Turing.org.uk](https://www.turing.org.uk/) - Platform dedicated to the life and work of Alan Turing, the mathematician and computer scientist.
+- [Sherlock Holmes Series](https://sherlock-holm.es/) - Sir Arthur Conan Doyle's Sherlock Holmes series (Public Domain, Copyright-free).
+- [Feynman Lectures Online](https://www.feynmanlectures.caltech.edu/) - Richard Feynman's lectures online.
+- [Leibniz Translations](https://www.leibniz-translations.com/index2.php) - Resource offering translations of the works of philosopher and mathematician Gottfried Wilhelm Leibniz.
+- [David Hume](https://davidhume.org/) - Platform dedicated to the Scottish philosopher David Hume. Accurate, helpful presentation of virtually everything Hume ever wrote.
+- [Fooled by Randomness](https://fooledbyrandomness.com/) - Nassim Nicholas Taleb's Home Page.
+- [Prabook](https://prabook.com/web/home.html) - Platform providing biographical information on notable individuals.
+- [Famous Mathematicians](https://famous-mathematicians.org/) - Website featuring information and biographies of famous mathematicians.
+
+### Books, Articles, Texts
+
+- [Archive.org/texts](https://archive.org/details/texts) - A digital library offering free universal access to a vast collection of digital content.
+- [Open Library](https://openlibrary.org/) - A universal catalog for book metadata with access to a wide range of digital books.
+- [OpenStax](https://openstax.org/) - Provides free and flexible textbooks and resources for educational purposes.
+- [Project Gutenberg](https://www.gutenberg.org/) - A digital library offering over 60,000 free eBooks, including many classics.
+- [Wikibooks](https://en.wikibooks.org/wiki/Main_Page) - An open-content collection of textbooks that anyone can edit.
+- [Wikisource](https://wikisource.org/wiki/Main_Page) - A free library that allows collaborative improvement of its content.
+- [MIT Classics](https://classics.mit.edu/) - Select from a list of 441 works of classical literature by 59 different authors.
+- [Goodreads Free eBooks](https://www.goodreads.com/ebooks?sort=readable) - Free books available on Goodreads.
+- [Lit2Go](https://etc.usf.edu/lit2go/) - A free online collection of stories and poems in audiobook format (Mp3).
+- [Booksc](https://booksc.org/) - World's largest scientific articles store with 70,000,000+ free articles.
+- [IntechOpen](https://www.intechopen.com/books) - Read, share, and download more than 5,800 peer-reviewed Open Access books.
+- [FreeTechBooks](https://www.freetechbooks.com/) - A database of free/open access online computer science books, textbooks, and lecture notes.
+- [FreeComputerBooks](https://freecomputerbooks.com/) - Platform offering a collection of free computer science and programming books.
+- [Manning](https://www.manning.com/) - A publisher of programming books.
+- [Holy Books](https://holybooks.com/) - Download spiritual texts as free PDF e-books.
+- [Librivox](https://librivox.org/) - Provides free public domain audiobooks read by volunteers from around the world.
+- [Online Books Page](https://onlinebooks.library.upenn.edu/) - A listing of over 3 million free books on the web.
+- [Audible](https://www.audible.com/) - A platform offering premium audio storytelling with a wide selection of audiobooks.
+- [VCU Transcendentalism](https://archive.vcu.edu/english/engweb/transcendentalism/) - An educational hypertext space on transcendental texts with links to other internet spaces.
+- [Library of Short Stories](https://www.libraryofshortstories.com/) - An online library with over 1000 classic short stories available for reading and download.
+- [SlideShare](https://www.slideshare.net/) - Online platform for sharing presentations and documents.
+- [Free-eBooks.net](https://www.free-ebooks.net/) - Discover 1000's of New Authors in Hundreds of Categories Fiction and Non-Fiction.
+- [University of Pennsylvania Digital Library](https://digital.library.upenn.edu/books/) - Digital library providing access to a collection of books.
+- [Feedbooks Public Domain](https://www.feedbooks.com/catalog/public_domain) - Platform offering a catalog of public domain books for free.
+- [Authorama](https://www.authorama.com/) - Platform providing a collection of public domain books by different authors.
+- [Google Play - Top Selling Free Books](https://play.google.com/store/books/collection/topselling_free?clp=ChcKFQoPdG9wc2VsbGluZ19mcmVlEAcYAQ%3D%3D:S:ANO1ljKuey8&gsr=ChkKFwoVCg90b3BzZWxsaW5nX2ZyZWUQBxgB:S:ANO1ljIbX7M) - Collection of top-selling free books on Google Play.
+- [Taoism.net](https://taoism.net/) - Resource for exploring Taoism.
+- [Early Modern Texts](https://earlymoderntexts.com/) - Platform providing modern English translations of early modern philosophical texts.
+- [Online Library of Liberty](https://oll.libertyfund.org/) - Curated collection of scholarly works that engage with vital questions of liberty.
+- [Online Books Library](https://onlinebooks.library.upenn.edu/) - University of Pennsylvania's online library providing access to 3 million free books on the Web.
+- [Elegant eBooks](https://www.ibiblio.org/ebooks/) - Find great classics of fiction and non-fiction in stylish editions. Almost all of the ebooks on this site were made from books that are in the public domain.
+- [22 Free Data Science Books](https://www.wzchen.com/data-science-books) - A compilation of quality data science books available for free, curated to assist those exploring the data science career track. The last updated date of each book is included in parentheses.
+- [Chest of Books](https://chestofbooks.com/) - Free online library offering a large collection of books on various topics, including science, technology, art, and literature.
+- [Stephen Wolfram: A New Kind of Science](https://www.wolframscience.com/nks/) - Online version of Stephen Wolfram's book "A New Kind of Science," offering access to the table of contents and related materials on cellular automata and complexity.
+- [Werewolf Reads](https://www.werewolfreads.com/) - A website that shares only werewolf related novels and stories
+
+#### Book Recommendations and Summaries
+
+- [Read Next](https://read-next.com/) (!) - A collection of 3,000+ books recommended by famous people from various domains such as scientists, investors, entrepreneurs, celebrities, and authors.
+- [Goodbooks](https://www.goodbooks.io/) - Offers 8,500+ book recommendations from successful and interesting individuals around the world.
+- [Most Recommended Books](https://mostrecommendedbooks.com/) - Curates 500+ experts, 600+ lists, 500+ book series, providing 100% verified book recommendations.
+- [Books Chatter](https://bookschatter.com/) - Find book recommendations from people's tweets, with tweets shown.
+- [Leafmarks](https://www.leafmarks.com/) - Explore book recommendations from famous authors, top CEOs, legendary investors, and favorite celebrities.
+- [Bookstash](https://bookstash.io/) - Features top books recommended by famous individuals, summarized in 3 minutes or less.
+- [Abakcus](https://abakcus.com/books/) - A collection of books about mathematics and some science.
+- [BookBub](https://www.bookbub.com/welcome) - Get personalized book recommendations based on your preferences.
+- [Hacker News Books](https://hackernewsbooks.com/) - Curates the best books mentioned on Hacker News each week.
+- [Goodreads](https://www.goodreads.com/) - The world's largest site for readers and book recommendations.
+- [What Should I Read Next?](https://www.whatshouldireadnext.com/) - Enter a book you like and the site will analyse our huge database of real readers' favorite books to provide book recommendations and suggestions for what to read next.
+- [Blas](https://blas.com/) - Summarizes more than 400 books by Blas Moros.
+- [Google Books - Talk to Books](https://books.google.com/talktobooks/) - Platform allowing users to have a conversation with books using natural language.
+- [Booktorium](https://booktorium.com/) - A highly user-friendly and constantly updated platform that provides comprehensive and well-organized book series orders, along with continuously improving features.
+
+
+### Maps and Data
+
+- [Our World in Data](https://ourworldindata.org/covid-vaccinations) - COVID-19 vaccination data by country.
+- [WebSDR](https://websdr.org/) - A Software-Defined Radio receiver connected to the internet, allowing many listeners to listen and tune it simultaneously, capturing current signals from Earth.
+- [GSM Security Map](https://gsmmap.org/) - A map comparing the protection capabilities of mobile networks regarding GSM security.
+- [International Campuses](https://cbert.org/resources-data/intl-campus/) - A list of international campuses.
+- [United States International College Campuses on Google Maps](https://www.google.com/maps/d/u/0/viewer?mid=1ckm_TSM8mbCrnhA8COpBNG-qJqTR2IW3&ll=43.664774893391936%2C24.56718262638249&z=5) - Map showcasing international college campuses in the United States.
+- [Submarine Cable Map](https://www.submarinecablemap.com/) - Interactive map showcasing the world's submarine cable systems.
+- [Observable](https://observablehq.com/) - A platform to explore, analyze, and explain data collaboratively.
+- [FixPhrase](https://fixphrase.com/) - Locate any place on Earth with just four words, useful for situations where dealing with a few words is more convenient than a long series of numbers.
+- [Common Crawl](https://commoncrawl.org/) - An open repository of web crawl data that can be accessed and analyzed by anyone.
+- [Mount Everest 3D Map](https://mount-everest3d.com/3d-map/) - Interactive 3D map of Mount Everest.
+- [Visualize Value Archive](https://archivve.visualizevalue.com/) - Archive of visual content from Visualize Value.
+- [Fliist](https://fliist.com/en) - Platform for creating and sharing your favorite lists.
+- [Search Engine Map](https://www.searchenginemap.com/) - Visual representation of popular search engines.
+- [Friendly Dubinsky](https://friendly-dubinsky-cb22fe.netlify.app/) - Maps of different places.
+- [Real-Time SpaceX Starlink Satellite Tracker](https://www.starlinkmap.org/) - Website providing a real-time tracker for SpaceX Starlink satellites.
+- [Album of Computational Fluid Motion](https://album-of-cfm.com/) - Collection showcasing computational fluid motion images.
+- [Visualization of Every Job Title in the World](https://duarteocarmo.com/blog/every-job-world) - Interactive visualization categorizing every single job title in the world into 10 categories.
+- [ObservableHQ](https://observablehq.com/@tophtucker/examples-of-bitemporal-charts) - Examples of bitemporal charts
+- [The Uncensored Library](https://uncensoredlibrary.com/en) - Minecraft server and map released by Reporters Without Borders and created by BlockWorks, DDB Berlin, and MediaMonks as an attempt to circumvent censorship in countries without freedom of the press
+- [Lighthouse Map](https://geodienst.github.io/lighthousemap/) - An interactive map displaying the locations of lighthouses around the world, offering geospatial information and history for each site.
+- [Wikipedia Landscape - Leland McInnes](https://lmcinnes.github.io/datamapplot_examples/wikipedia/) - Visualization showcasing the landscape of Wikipedia.
+- [AAA Gas Prices](https://gasprices.aaa.com/) - Average fuel prices updated daily from up to 120,000 U.S. stations, compiled by OPIS and WEX.
+- [ASCE Hazard Tool](https://ascehazardtool.org/) - Design parameters for structures retrieved based on ASCE standards, including seismic, wind, and flood data.
+
+#### Arxiv
+
+- [ArxivXplorer](https://arxivxplorer.com/) - Search tool designed for exploring scientific papers on arXiv, allowing users to find and filter research articles across various disciplines.
+- [Interactive Data Map of ArXiv Machine Learning Papers](https://datamapplot.readthedocs.io/en/latest/auto_examples/plot_interactive_arxiv_ml.html) - Interactive data map displaying papers from the Machine Learning section of ArXiv.
+- [ArXiv Machine Learning Landscapa - Leland McInnes](https://lmcinnes.github.io/datamapplot_examples/ArXiv_data_map_example.html) - Visualization showcasing the landscape of machine learning research on ArXiv.
+- [DataMap Landscape - Leland McInnes](https://lmcinnes.github.io/datamapplot_examples/arXiv/) - A collection of examples and demonstrations for visualizing data on manifolds using the DataMapPlot library, focusing on arXiv datasets.
+
+### Infographic
+
+- [Information is Beautiful](https://informationisbeautiful.net/) - Platform focusing on fact- and data-based decisions, presenting information through visually appealing graphics.
+- [Visual Capitalist](https://www.visualcapitalist.com/) - Source of data-driven visuals covering various topics such as markets, technology, energy, and the global economy.
+- [Infographic Journal](https://infographicjournal.com/) - Archive of infographics covering a wide range of topics.
+- [D3.js](https://d3js.org/) - JavaScript library for manipulating documents based on data, enabling the creation of dynamic and interactive data visualizations.
+- [Deniz Cem On Duygu Portfolio](https://www.denizcemonduygu.com/) - Personal portfolio of infographics.
+- [Data Visualization Catalogue](https://datavizcatalogue.com/index.html) - Catalog providing information on various types of data visualizations.
+- [Tableau Public](https://public.tableau.com/app/discover) - Free platform to explore, create, and publicly share data visualizations online.
+- [Will Robots Take My Job?](https://willrobotstakemyjob.com/) - Estimates the automation risk, growth, wages, and more for various jobs.
+- [Preceden](https://www.preceden.com/) - Online timeline and roadmaps maker.
+- [Jason Davies](https://www.jasondavies.com/) - Personal website of Jason Davies showcasing his projects and visualizations.
+
+### Philosophy
+
+- [Desolhar Philo](https://www.desolhar-philo.com/) - Notes about philosophy.
+- [VisualizingSEP](https://www.visualizingsep.com/) - Interactive visualization and search engine for exploring the Stanford Encyclopedia of Philosophy.
+- [Hakob's Sandbox](https://hakobsandbox.openetext.utoronto.ca/) - Online book on the introduction to the history and philosophy of science.
+- [Philosophy A Level](https://philosophyalevel.com/)
+- [Deniz Cemon Duygu - History of Philosophy](https://www.denizcemonduygu.com/philo/browse/) - Summarized & Visualized.
+- [Interactive timeline of philosophical ideas](https://www.denizcemonduygu.com/portfolio/the-history-of-philosophy/). - Visual representation and exploration of the significant philosophers and their ideas.
+- [Beyng](https://www.beyng.com/) - A resource dedicated to Martin Heidegger's philosophy, providing English translations and discussions of his works and ideas.
+- [Greg Egan's Official Website](https://www.gregegan.net/) - Information about the works, philosophy, and projects of science fiction author and computer programmer Greg Egan is presented.
+- [Ayn Rand Institute Courses](https://courses.aynrand.org/) - Educational platform offering free courses on Ayn Rand's philosophy, including Objectivism and its application to life and society.
+
+### Social Sciences
+
+- [Temple Manifold - All Projects](https://temple.manifoldapp.org/projects/all) - A collection of great resources on various social sciences.
+
+### History
+
+- [Histography](https://histography.io/) - An interactive timeline that spans across 14 billion years of history, from the Big Bang to 2015.
+- [Unenumerated Blog](https://unenumerated.blogspot.com/) - A comprehensive and highly detailed blog covering various history topics.
+- [Human Origins - Human Family Tree](https://humanorigins.si.edu/evidence/human-family-tree) - An interactive Human Family Tree that explores the evolutionary history of humans.
+- [OldEra Timeline](https://timeline.oldera.org/) - An interactive timeline that allows you to view the entire history on a zoomable interface.
+- [Nuclear Secrecy Blog](https://blog.nuclearsecrecy.com/) - Historical information about nuclear secrecy, providing insights into the development and implications of nuclear weapons.
+- [The Ascent of Humanity](https://ascentofhumanity.com/) - Explores the concept of the Age of Separation, the Age of Reunion, and the convergence of crises shaping the transition in human history.
+- [Today in Science History](https://todayinsci.com/) - Platform offering historical events of a given date.
+- [Khipu Field Guide](https://khipufieldguide.com/guidebook/Introduction.html) - Guidebook providing information on khipus, the ancient Incan system of knotted strings for record-keeping.
+- [Hellenistic History](https://www.hellenistichistory.com/) - Resource for the study of Hellenistic history, covering the political, cultural, and social developments from Alexander the Great's era to the Roman Empire.
+- [Perseus Digital Library](https://www.perseus.tufts.edu/hopper/) - Provides a vast collection of classical texts, images, and resources for the study of ancient Greek and Roman cultures.
+- [Futility Closet](https://www.futilitycloset.com/) - Collection of entertaining curiosities in history, literature, language, art, philosophy, and mathematics, designed to help you waste time as enjoyably as possible.
+
+### Geoscience
+
+- [River Runner Global](https://river-runner-global.samlearner.com/) - Offers a visualization of the path of a rain droplet from any point in the world to its end point.
+- [Celestrak Satellite Visualization](https://celestrak.com/cesium/orbit-viz.php?tle=/pub/TLE/catalog.txt&satcat=/pub/satcat.txt&referenceFrame=1) - Provides satellite visualization tools.
+- [Mars Now](https://mars.nasa.gov/explore/mars-now/) - Shows the current positions of Mars's satellites, offering insights into Martian exploration.
+- [Physical Geology](https://temple.manifoldapp.org/projects/physical-geology) - Covers essential topics in Physical Geology.
+- [Flood Site](https://floodsite.net/juniorfloodsite/) - An educational resource about flooding.
+- [NEMO - Nucleus for European Modeling of the Ocean](https://www.nemo-ocean.eu/) - Platform providing information and resources related to ocean modeling for multifarious space and time scales, developed by a European consortium.
+- [USGS Earthquake Map](https://earthquake.usgs.gov/earthquakes/map/?extent=25.56227,4.08691&extent=45.08904,70.00488&list=false) - Map displaying recent earthquake activity from the United States Geological Survey.
+- [LatLong.net](https://www.latlong.net/) - Tool for finding latitude and longitude coordinates for any location on a map, providing geographic coordinates and related data.
+- [Latitude.to](https://latitude.to/) - Allows users to find GPS coordinates for any address or location worldwide, with detailed mapping features.
+
+### Biology
+
+- [Sectional Anatomy](https://www.sectional-anatomy.org/) - Free online tool for radiologic cross-sectional anatomy.
+- [Deep Sea](https://neal.fun/deep-sea/) - Platform to explore the depths of the seas.
+- [Ask Nature](https://asknature.org/) - Biology-inspired strategies, innovations, or educational resources.
+- [We Are Hosts for Memes](https://wearehostsformemes.com/) - You have been exposed to The Meta-meme
+- [Birdwatching Zone](https://birdwatching.zone/) - A site dedicated to birdwatching, featuring over 300 species recorded with identification tips and resources for enthusiasts.
+- [OneZoom](https://www.onezoom.org/) - The Tree of Life that illustrates how all life on Earth is connected. Explore relationships between 2.2 million species, view over 100,000 images, and see how species evolved from common ancestors. Zoom through the tree to discover the diversity of life on Earth.
+
+## Physics
+
+- [The Theoretical Minimum](https://theoreticalminimum.com/home) - Series of Stanford Continuing Studies courses taught by world-renowned physicist Leonard Susskind.
+- [Theoretical Physics - Cambridge](https://www.damtp.cam.ac.uk/user/tong/index.html) - Resources and information about theoretical physics from the University of Cambridge.
+- [University of Virginia Classical and Modern Physics II](https://galileo.phys.virginia.edu/classes/632.ral5q.summer06/lectures.html) - Lecture notes and materials for the Classical and Modern Physics II course at the University of Virginia.
+- [Mueller Group - Cornell](https://muellergroup.lassp.cornell.edu/index.html) - Laboratory of Atomic and Solid State Physics at Cornell University.
+- [Ptable](https://ptable.com/?lang=en) - Interactive and customizable periodic table providing information about elements and their properties.
+- [National Institute of Standards and Technology – Fundamental Physical Constants](https://www.nist.gov/pml/fundamental-physical-constants) - Offers authoritative data on physical constants, providing essential measurements for research and technological applications.
+- [Mechanics Map](https://mechanicsmap.psu.edu/index.html) - Interactive resource from Penn State University for exploring mechanical systems and understanding basic mechanics principles.
+
+### Quantum
+
+- [Quasihome Interference](https://vsg.quasihome.com/interfer.htm) - Applet of Young's Double Slit Interference
+
+#### Quantum Games
+
+- [Virtual Lab by Quantum Flytrap](https://quantumflytrap.com/lab) - Simulates optical experiments with multiparticle quantum systems, supporting quantum key distribution and entanglement exploration.
+- [Hello Quantum](https://quantum-computing.ibm.com/lab) - Introduces quantum circuits and gates via interactive puzzle games, featuring graphical interfaces to simplify quantum concepts.
+- [Particle in a Box](https://learnqm.gatech.edu) - Demonstrates quantum superposition and energy levels through a 2D single-player platformer contrasting classical and quantum physics.
+- [Psi and Delta](https://learnqm.gatech.edu) - Encourages collaborative learning of quantum mechanics using cooperative gameplay focused on superposition and quantum probabilities.
+- [QPlayLearn](https://qplaylearn.com) - Offers interactive tools, videos, and games for multi-level education on quantum physics, addressing diverse learner profiles.
+- [Quantum Odyssey](https://quarksinteractive.com) - Visualizes quantum algorithm development through a game-like interface, aiding education in quantum computing logic and state evolution.
+- [Quantum Moves 2](https://www.scienceathome.org/games/quantum-moves-2) - Engages citizen scientists in optimizing quantum experiments, addressing real-world challenges in quantum optimization.
+- [The Virtual Quantum Optics Laboratory](https://www.vqol.org/) - Enables design and simulation of quantum optics experiments, bridging classical and quantum mechanics for educational use.
+- [Arxiv Paper - Quantum Games and Interactive Tools for Quantum Technologies Outreach and Education](https://arxiv.org/abs/2202.07756) - Comprehensive discussion of the use of games and interactive tools to engage the public in understanding quantum technologies.
+
+### Astronomy
+
+- [Fear of Physics](https://www.fearofphysics.com/) - Offers a free "Astronomy 101" course.
+- [Galileo's Applets](https://galileo.phys.virginia.edu/classes/109N/more_stuff/Applets/home.html) - Provides applets on early lunar observations and various motion-related topics.
+- [100,000 Stars](https://stars.chromeexperiments.com/) - A visualization of 100,000 nearby stars, providing an immersive experience.
+- [The Million Earth Solar System](https://planetplanet.net/2018/06/01/the-million-earth-solar-system/) - Explores the concept of a solar system with a million Earth-like planets.
+- [Space Telescope Live](https://spacetelescopelive.org/webb) - Live access to real-time data and observations from the James Webb Space Telescope, allowing users to explore space research and discoveries.
+- [Telescope Optics](https://www.telescope-optics.net/) - A resource for amateur telescope builders, providing detailed information on designing and constructing telescope optics.
+- [Orbital Basics](https://t-neumann.github.io/space/OrbitalBasics/) - Educational resource explaining the fundamental concepts of orbital mechanics, designed for beginners in space science.
+- [Webb Telescope](https://webbtelescope.org/) - Official website for the James Webb Space Telescope.
+
+## Mathematics
+
+- [Open Logic Text](https://openlogicproject.org/about/) - Open-source, modular, collaboratively authored collection of teaching materials for formal (meta)logic and formal methodss.
+- [OEIS - The On-Line Encyclopedia of Integer Sequences](https://oeis.org/) - Platform providing a comprehensive database of integer sequences.
+- [First Principles of Mathematics](https://pdodds.w3.uvm.edu/) - Resource covering first principles of various math topics.
+- [38 Best Math Websites for Students](https://blog.symbaloo.com/webmixes/11/best-math-websites) - Compilation of 38 recommended math websites for students.
+- [Math Hints](https://mathhints.com/) - Free website with simple explanations and examples for various math topics.
+- [Better Explained](https://betterexplained.com/) - Platform focusing on understanding math concepts rather than memorization, with clear lessons on topics like imaginary numbers and exponents.
+- [Mathway](https://www.mathway.com/) - Free math problem solver.
+- [ChiliMath](https://www.chilimath.com/) - Online resource for math topics.
+- [Visual and Interactive Introduction to Complex Analysis](https://complex-analysis.com/) - Resource providing a visual and interactive introduction to complex analysis.
+- [Matrices as Tensor Network Diagrams](https://www.math3ma.com/blog/matrices-as-tensor-network-diagrams) - Article discussing matrices represented as tensor network diagrams.
+- [What is Category Theory Anyway?](https://www.math3ma.com/blog/what-is-category-theory-anyway) - Exploring the grand scheme of mathematical things with category theory.
+- [Algebra Practice Problems](https://www.algebrapracticeproblems.com/) - Platform offering algebra practice problems with clear explanations.
+- [Matrixology](https://pdodds.w3.uvm.edu/teaching/courses/2016-08UVM-122/) - Matrixology course resource.
+- [Math Courses at NITK](https://sam.nitk.ac.in/courses-taught.html) - List of math courses taught at the National Institute of Technology Karnataka (NITK).
+- [Easy Mathematical Tricks from Counting Through Calculus](https://mathhints.com/) - Collection of easy mathematical tricks from counting through calculus.
+- [Math Salamanders](https://www.math-salamanders.com/) - Platform providing useful calculators (like Reverse Percentage Calculator) and math worksheets for kids or students.
+- [3Blue1Brown Non-Videos](https://some.3b1b.co/non-videos) - Non-video content winners of 3Blue1Brown's SoME.
+- [Mathigon – The Mathematical Playground](https://mathigon.org/) - Interactive mathematics platform offering educational content and resources.
+- [Math Warehouse](https://www.mathwarehouse.com/) - Offers interactive math activities, demonstrations, lessons with definitions and examples, worksheets, and other resources.
+- [Cut the Knot](https://www.cut-the-knot.org/) - Resource offering interactive math puzzles, problems, and visualizations to explore mathematical concepts through problem-solving.
+- [Trigonography](https://trigonography.com/?page_id=230) - Site exploring trigonometry and its applications, featuring visual aids, formulas, and problem-solving techniques.
+- [Lamar Math Tutorials](https://tutorial.math.lamar.edu/) - A comprehensive collection of math tutorials and practice problems, covering topics from algebra to calculus and differential equations.
+- [Art of Problem Solving](https://artofproblemsolving.com/company) - Focuses on developing problem-solving skills across various subjects including mathematics, physics, programming, and language arts. Offers rigorous online classes, physical academies, and an engaging curriculum designed to encourage critical thinking, experimentation, and perseverance in students.
+- [Mathematics Genealogy Project](https://genealogy.math.ndsu.nodak.edu/index.php) - Aims to compile and share comprehensive information on mathematicians worldwide, gathering data from academic institutions and individual contributors.
+- [Enjeck Complicated Math Equation Generator](https://enjeck.com/num2math/?input=4&submit=Generate) - Generates complex mathematical equations based on user input, offering a tool for practicing or visualizing mathematical problems.
+- [Erdos Problems](https://www.erdosproblems.com/) - A site dedicated to exploring open mathematical problems related to Paul Erdős, including ongoing challenges in number theory and combinatorics.
+- [The Electronic Journal of Combinatorics](https://www.combinatorics.org/ojs/index.php/eljc) - An open-access journal publishing research papers and articles on combinatorics, an area of mathematics dealing with counting, arrangement, and structure.
+- [Zeta by Amir Hirsch](https://amirhirsch.com/zeta/index.html) - Website dedicated to the exploration of the Riemann Hypothesis, with interactive tools and resources for those interested in number theory.
+- [Tungsteno](https://www.tungsteno.io/) - A platform providing pedagogical tools to make mathematics accessible to everybody, completely free, based on open collaboration.
+- [PlanetMath](https://planetmath.org/) - Online mathematical resource and collaborative platform that provides open-access mathematics content, including definitions, theorems, and proofs.
+- [Geomstats Tutorials](https://geomstats.github.io/tutorials/index.html) - Tutorials and resources on geometric statistics, providing practical examples and code for implementing statistical techniques on manifolds.
+- [Ximera - MOOCulus](https://ximera.osu.edu/mooculus) - Collection of interactive math modules and learning resources designed for online courses, focusing on calculus and related subjects.
+- [EuclideanSpace](https://euclideanspace.com) - Topics in mathematics and computing explained through visualizations and detailed references.
+
+### Math + Art
+
+- [Paul Nylander's website](https://bugman123.com/) - Favorite hobbies and interests, especially science, and art of Paul Nylander
+- [NYC DOE CS4All](https://nycdoe-cs4all.github.io/) - Introduction to Computational Media with p5.js
+- [Texample](https://texample.net/) - Examples and community of LaTeX
+- [Snowflakes Project](https://www.dynamicmath.xyz/collective-math-art/) - Snowflakes project by Collective Mathematical Art
+
+## Engineering
+
+- [Animagraffs](https://animagraffs.com/) - Educational website featuring detailed animated infographics (animagraffs) that visually explain complex topics and processes across various subjects.
+- [Technology Student](https://technologystudent.com/index.htm) - A resource containing numerous information sheets, exercises, and animations, covering various technology-related topics.
+- [Nuclear Power](https://www.nuclear-power.com/) - A non-profit project aimed at learning the basics of nuclear and reactor physics, covering topics such as nuclear power plants, reactor physics, thermal engineering, materials, and radiation protection.
+- [Knovel](https://app.knovel.com/kn) - A platform providing tools and calculators for various engineering and scientific purposes.
+- [Engineering Library](https://engineeringlibrary.org/reference/) - Reference library for engineering topics.
+- [Engineering Toolbox](https://www.engineeringtoolbox.com/index.html) - Online resource providing engineering tools and information.
+- [Text to CAD](https://text-to-cad.zoo.dev/) - Tool converting textual descriptions into CAD models, helping users generate technical drawings from written input.
+- [McMaster-Carr](https://www.mcmaster.com/) - Supplier of hardware, tools, raw materials, industrial materials, and maintenance equipment, serving a wide range of industries with an extensive catalog of products.
+- [Engineer on a Disk: Modeling](https://engineeronadisk.com/book_modeling/modelTOC.html) - A book offering a hands-on guide to system modeling and simulation, with practical examples and explanations for engineers and developers.
+- [Bartosz Ciechanowski Archives](https://ciechanow.ski/archives/) - Collection of articles on design and technology by Bartosz Ciechanowski.
+- [IQS Directory Articles](https://www.iqsdirectory.com/articles/) - Industrial components explained through technical articles and manufacturer insights.
+
+### Civil Engineering
+
+- [Floor Plan Lab](https://floorplanlab.com/) - Platform for creating and visualizing floorplans.
+- [Engineers Edge](https://www.engineersedge.com/) - Platform providing articles and resources on structural and mechanical engineering topics.
+- [3D House Planner](https://3dhouseplanner.com/) - Free 3D floor planner application on the web.
+
+### Mechanical Engineering
+
+- [507 Movements](https://507movements.com/toc.html) - Website featuring animated mechanical movements, providing a visual understanding of various mechanical systems.
+- [MadeHow](https://www.madehow.com/) - Resource explaining and detailing the manufacturing processes of a wide variety of products.
+- [Comprehensive Structural Analysis Book](https://temple.manifoldapp.org/projects/structural-analysis) - Online resource offering a comprehensive book on structural analysis.
+- [Awesome MechEng](https://github.com/m2n037/awesome-mecheng#heat-transfer) - Awesome Mechanical Engineering Resources.
+- [Animated Dynamics](https://dynref.engr.illinois.edu/ref.html) - Interactive reference for visualizing dynamics simulations, aimed at helping users better understand complex mechanical systems.
+- [Wikimedia Commons - Engine Animations](https://commons.wikimedia.org/wiki/Category:Animations_of_engines) - A collection of animated images and videos that demonstrate the functioning of various types of engines, from combustion to electric.
+- [Mechanisms/menu-gear](https://www.mekanizmalar.com/menu-gear.html) - Gear mechanisms animated.
+- [Mechanism Animations](https://people.ohio.edu/williams/html/MechanismAnimations.html) - Offers interactive animations that demonstrate mechanical systems and mechanisms, helping users visualize and understand their motion and function.
+- [CalcResource](https://calcresource.com/resources.html) - Regularly updated list of resources focused on mechanics and statics, aiding in learning and understanding these subjects.
+- [Engineering Toolbox](https://www.engineeringtoolbox.com/) - Comprehensive resource covering a wide range of engineering topics.
+- [StructX](https://structx.com/) - Website offering structural engineering resources for professionals and students.
+- [Amesweb](https://www.amesweb.info/) - Platform with calculators and articles covering various engineering topics.
+- [RoyMech](https://www.roymech.co.uk/) - Reference site with in-depth articles on structural and mechanical engineering subjects.
+- [Arcelor-Mittal Design Software](https://sections.arcelormittal.com/design_aid/design_software/EN) - Free design software for steel structures provided by Arcelor-Mittal.
+- [BU Moss](https://www.bu.edu/moss/) - Courses and resources focused on understanding slender structures.
+- [Homestyler](https://www.homestyler.com/) - Easy and time-saving online interior design tool catering to both professionals and amateurs.
+- [How a Car Works](https://www.howacarworks.com/) - Complete and free guide explaining how cars work.
+- [IIHS Ratings](https://www.iihs.org/ratings) - Crash test ratings and safety information from the Insurance Institute for Highway Safety.
+- [Euro NCAP](https://www.euroncap.com/en/) - European New Car Assessment Programme providing safety ratings for vehicles.
+- [Toaster Museum](http://toastermuseum.com/) - A dedicated collection of antique toasters, showcasing vintage models for toaster enthusiasts and collectors, along with historical information and preservation details.
+
+#### Materials / Nanotechnology
+
+- [DoITPoMS](https://www.doitpoms.ac.uk/index.php) - DoITPoMS from Department of Materials Science and Metallurgy, University of Cambridge
+- [Nanoscience Resources](https://ssd.phys.strath.ac.uk/) - Nanoscience resources of the Department of Physics at the University of Strathclyde
+- [StatNano](https://product.statnano.com/) - Reliable source of information about nanotechnology products, currently used in a broad range of industrial applications
+- [MyMiniFactory](https://www.myminifactory.com/) - World’s largest ecosystem of free to download, 3D printable objects of cultural significance
+- [Roy Mech](https://roymech.org/) - This site provides useful information, tables , schedules and formula related to mechanical engineering and engineering materials.
+
+### Electronics Engineering
+
+- [Electrical4U](https://www.electrical4u.com/) - Platform for learning electrical engineering.
+- [Electronics Tutorials](https://www.electronics-tutorials.ws/) - Resource providing tutorials on various aspects of electronics.
+- [Octopart](https://octopart.com/) - Search engine for electronic and industrial parts. It aggregates parts from distributors and manufacturers online, making them easy to search for and purchase.
+- [TechSpot - How CPUs Are Designed and Built](https://www.techspot.com/article/1821-how-cpus-are-designed-and-built/) - Series covering computer architecture, processor circuit design, VLSI, chip fabrication, and future trends in computing.
+- [Open Circuits Book](https://www.opencircuitsbook.com/) - "Open Circuits" is a photographic exploration of the beautiful design inside everyday electronics.
+- [Digi-Key Electronics](https://www.digikey.com/) - Online marketplace for electronic components, featuring a vast selection of parts, tools, and resources for engineers and makers.
+- [Telematic Connections Timeline](http://telematic.walkerart.org/timeline/index.html) - Interactive timeline exploring the history and impact of telematics and networked communication, with a focus on art and technology.
+- [Cybergraph](https://cybergraph.dubberly.com/#) - Visual exploration of Cybernetics, offering interactive representations of networks.
+- [EveryCircuit](https://everycircuit.com/) - Electronic circuits simulated and visualized in real time with interactive component behavior.
+- [Falstad Circuit Simulator](https://www.falstad.com/circuit/) - Electronic circuits modeled and tested in-browser using animated schematic diagrams.
+
+## Computer Science
+
+- [Webopedia](https://www.webopedia.com/) - Online tech dictionary, study guides, and reviews for computer and IT terms.
+- [Teach Yourself Computer Science](https://teachyourselfcs.com/) - Comprehensive guide for self-study in computer science.
+- [Open Source Society University - Computer Science](https://github.com/open-source-society/computer-science) - Curriculum for computer science studies provided by the Open Source Society University.
+- [Functional Computer Science Curriculum](https://functionalcs.github.io/curriculum/) - Curriculum focusing on functional programming concepts in computer science.
+- [Menimagerie](https://www.menimagerie.com/) - Explore concepts in theoretical computer science, from the number system to Cantor infinities, Godel's theorems, and automat.
+- [Computer Science Library](https://www.compscilib.com/) - Platform aiding in mastering concepts in computer science and math courses with automated step-by-step solutions and practice problems.
+- [Computer Jargon](https://www.computerhope.com/jargon.htm) - Glossary of computer-related jargon and technical terms.
+- [Talks by Alan Kay](https://tinlizzie.org/IA/index.php/Talks_by_Alan_Kay) - Collection of talks by computer scientist Alan Kay.
+- [Everything Computer Science](https://everythingcomputerscience.com/) - A wide range of articles and tutorials on computer science topics, including programming, algorithms, data structures, and software development practices.
+- [Richard Sutton Video Lectures](https://videolectures.net/search/?query=Richard%20sutton) - Collection of video lectures and talks by Richard Sutton, a prominent researcher in reinforcement learning and artificial intelligence.
+
+### Data Structures and Algorithms (DS&A)
+
+- [Dictionary of Algorithms and Data Structures](https://xlinux.nist.gov/dads/) - NIST's Dictionary of Algorithms and Data Structures.
+- [Visualgo](https://visualgo.net/en) - Platform for visualizing data structures and algorithms through animations.
+- [Adventures In Coding & Algorithms](https://entcheva.github.io/) - Blog exploring coding and algorithms.
+- [Damn Cool Algorithms](https://blog.notdot.net/tag/damn-cool-algorithms) - Blog featuring posts on particularly interesting algorithms.
+- [Skiena's Algorithms Lectures](https://www3.cs.stonybrook.edu/~algorith/video-lectures/) - Video lectures on algorithms by Steven Skiena.
+- [Visual Algorithms](https://thimbleby.gitlab.io/algorithm-wiki-site/) - Platform presenting visual representations of algorithms.
+- [Sinon - Algorithms](https://sinon.org/algorithms/) - Summarized page covering important results from computer science.
+
+### Big-O notation
+
+- [Algorithms and Data Structures Big-O Notation](https://cooervo.github.io/Algorithms-DataStructures-BigONotation/) - Comprehensive resource covering Big-O notation for various algorithms and data structures.
+- [Big-O Cheat Sheet](https://www.bigocheatsheet.com/) - Webpage presenting the space and time complexities (Big-O) of common algorithms used in Computer Science.
+- [Comp160 Data Cheat](https://www.clear.rice.edu/comp160/data_cheat.html) - Resource providing information on data structures and related concepts in computer science.
+
+## AI/ML
+
+- [Doublespeak Chat](https://doublespeak.chat/#/handbook) - Empirical, non-academic, and practical guide to LLM hacking.
+- [Fast.ai Course](https://course.fast.ai/) - Online course for deep learning and machine learning.
+- [Papers with Code](https://paperswithcode.com/sota) - Collection of state-of-the-art results for machine learning tasks with associated code.
+- [Delta Academy Maps](https://maps.joindeltaacademy.com/) - Map of mathematics for Machine Learning.
+- [Inside the Matrix by PyTorch](https://pytorch.org/blog/inside-the-matrix/) - Blog post by PyTorch that is visualizing matrix multiplication, attention and beyond.
+- [Directory of AI Models](https://docs.google.com/spreadsheets/d/1gc6yse74XCwBx028HV_cvdxwXkmXejVjkO-Mz2uwE0k/edit?pli=1#gid=0) - Google Sheets document providing a directory of various AI models, presenting information such as name, date, parameters, organization, organization type, author location, language, commercial use, model, accessibility, code accessibility, data accessibility, major datasets used, and architecture.
+- [Papers with Code](https://paperswithcode.com/) - Platform providing the latest in machine learning research papers along with code implementations and benchmarks.
+- [Globe Engineer Explorer](https://explorer.globe.engineer/) - Applied AI company making products that optimally represent information for human comprehension.
+- [Colah's Blog](https://colah.github.io/) - Blog by Christopher Olah on deep learning and artificial intelligence, featuring detailed explanations, tutorials, and research insights.
+- [TensorFlow Playground](https://playground.tensorflow.org) - An interactive tool for experimenting with neural networks, allowing users to visualize how different configurations affect model training and classification tasks.
+- [Ben's Bites](https://bensbites.com/catalog) - Catalog offering a variety of bite-sized AI resources.
+
+### Robotics
+
+- [Robots Guide](https://robotsguide.com/) - A comprehensive resource offering guides, reviews, and insights on robotics, aimed at both beginners and enthusiasts in the world of robotics.
+- [Control Challenges](https://janismac.github.io/ControlChallenges/) - Leetcode for robotics.
+
+### LLMs
+
+- [Hacker Llama](https://osanseviero.github.io/hackerllama/blog/posts/hitchhiker_guide/) - Blog post on the useful terms to know when joining the Local LLM community.
+- [Moebio Mind](https://moebio.com/mind/) - Explores the inner workings of language models, visualizing the semantic space and trajectories of word completions generated by the GPT-3 API. The site demonstrates how responses evolve through high-dimensional spaces and presents interactive visualizations of word sequences and their probabilities, offering a unique perspective on machine-generated intelligence.
+- [LLM Visualization](https://bbycroft.net/llm) - Interactive tool for visualizing large language models (LLMs) and exploring their structure, behavior, and outputs.
+- [RR LM Game](https://rr-lm-game.herokuapp.com/) - Browser-based Language modelling game.
+
+#### Prompt Engineering
+
+- [PromptPerfect](https://promptperfect.jina.ai/) - Cutting-edge prompt optimizer designed for large language models (LLMs), large models (LMs), and LMOps.
+- [Jailbreak Chat](https://www.jailbreakchat.com/) - Jailbreak collection for LLMs.
+- [MidJourney Styles and Keywords Reference](https://github.com/willwulfken/MidJourney-Styles-and-Keywords-Reference) - Styles and keywords for AI image generation.
+- [QuickRef ChatGPT](https://quickref.me/chatgpt) - ChatGPT cheatsheet.
+- [OpenAI Cookbook](https://cookbook.openai.com/) - Cookbook by OpenAI providing practical guides for working with AI.
+- [Prompting Guide](https://www.promptingguide.ai/) - Resource for creating effective prompts for AI models.
+- [Instaprompt](https://www.instaprompt.ai/?ref=producthunt) - Platform offering instant prompts for writing.
+- [Midjourney Prompt Helper](https://promptfolder.com/midjourney-prompt-helper/) - Assists users in generating detailed and effective prompts for Midjourney, enabling the creation of high-quality images through natural language inputs.
+- [Free Midjourney Prompt](https://www.freemidjourneyprompt.com/) - Offers a wide selection of free Midjourney prompts, allowing users to easily generate images by providing optimized natural language prompts.
+- [Prompt Engineering Guide](https://learnprompting.org/docs/introduction) - Serves as a comprehensive guide to prompt engineering, offering essential principles and techniques for crafting effective prompts for AI models and creative tasks.
+
+### AI tools
+
+- [Future Tools](https://www.futuretools.io/) - Platform for finding the exact AI tool for your needs.
+- [WarpSound AI](https://www.warpsound.ai/) - Create high-quality generative AI music in seconds with just prompts.
+- [AI Tools Arena](https://aitoolsarena.com/) - Platform showcasing various AI tools and resources.
+- [Klavier AI](https://klavier.ai/) - Allows you to do Q&A with ChatGPT on web pages and docs you choose.
+- [Aiva Valley](https://aivalley.ai/) - The latest source of AI tools and prompts.
+- [Bardeen AI](https://www.bardeen.ai/) - Automate manual work and tasks with AI without any code in minutes.
+- [Speechify](https://speechify.com/) - Power through documents, articles, PDFs, email—anything you read—by listening with their leading AI text-to-speech reader.
+- [Humata AI](https://www.humata.ai/) - Upload any PDF or document and get answers from it in seconds.
+- [Syntelly](https://app.syntelly.com/search) - Artificial intelligence for organic and medical chemistry.
+- [Warp.dev - Warp AI](https://www.warp.dev/warp-ai?source=producthunt&ref=producthunt) - AI-powered tool for building APIs without writing code.
+- [Feedback by AI](https://feedbackbyai.com/?ref=producthunt) - Platform utilizing AI for generating actionable feedback on writing.
+- [Seeing the World through Your Eyes](https://world-from-eyes.github.io/) - Reconstruct the world that is reflected through human eyes.
+- [Auxiliary Tools](https://www.auxiliary.tools/) - Platform offering AI experiments and tools for humans.
+- [Hemingway Editor](https://hemingwayapp.com/) - Spellchecker, but for style.
+- [FuturePedia](https://www.futurepedia.io/) - Leading AI resource platform dedicated to empowering professionals across various industries to leverage AI technologies for innovation and growth.
+- [ExplainPaper](https://www.explainpaper.com/) - Platform where users can upload a research paper, highlight confusing text, and receive an explanation to make research papers easier to read.
+- [Summarize Tech](https://www.summarize.tech/) - AI-powered tool to get a summary of any long YouTube video, such as lectures, live events, or government meetings.
+- [YouTubeTranscript](https://youtubetranscript.com/) - Get a YouTube video transcript and summaries
+
+### Data Science
+
+- [DataTau](https://www.datatau.com/news) - Hackernews but for data
+- [DatasetList](https://www.datasetlist.com/) - List of machine learning datasets from across the web
+- [Stat Learning](https://www.statlearning.com/) - Platform for learning statistics and related topics.
+
+### Databases
+
+- [ImageNet](https://www.image-net.org/) - Image database organized according to the WordNet hierarchy.
+- [DataSheets.com](https://www.datasheets.com/) - Searchable database of electronic component datasheets and purchasing information, designed for design engineers and electronics purchasing agents.
+- [Academic Torrents](https://academictorrents.com/) - Community-driven platform for sharing large datasets, offering torrents for academic research, including scientific papers, datasets, and multimedia.
+- [DBLP](https://dblp.org/) - Comprehensive, open-access database providing bibliographic information on major computer science journals, conferences, and proceedings.
+
+## Web Development
+
+- [Mozilla Developer Network](https://developer.mozilla.org/en-US/) - Documentation for web technologies, including CSS, HTML, and JavaScript.
+- [W3C](https://www.w3.org/) - World Wide Web Consortium's official website, making it possible to use web technologies with different languages, scripts, and cultures.
+- [UX Core](https://keepsimple.io/uxcore) - UX Core allows you to explore many cognitive biases while creating software.
+- [Coggle](https://coggle.it/diagram/Vz9LvW8byvN0I38x/t/web-development) - Collaborative mind-mapping tool for visualizing and organizing ideas related to web development.
+- [Web.dev Learn](https://web.dev/learn) - Educational platform by Google providing resources and tutorials for web development.
+- [WebDevHome](https://webdevhome.github.io/) - Collection of web development resources and tutorials.
+- [Web Dev Resources](https://web-dev-resources.com/#/) - Curated list of awesome web development resources for developers.
+- [BBC Microbit Editor](https://bbcmic.ro/) - Basic editor from BBC for Microbit programming.
+- [DemoFox](https://blog.demofox.org/) - Blog with various links related to programming and development.
+- [Timeline of Web Browsers](https://super-static-assets.s3.amazonaws.com/bc2689f0-a124-4777-93dc-416ee1aa4858/images/7db6532c-14f1-4c51-a337-b3021a7293bf.svg) - Visualization of the timeline of web browsers until 2019.
+- [Is Houdini Ready Yet?](https://ishoudinireadyyet.com/) - Tool to check the readiness status of various Houdini specifications in web browsers.
+- [Artillery](https://www.artillery.io/) - Modern load testing and smoke testing tool for SRE (Site Reliability Engineering) and DevOps.
+- [Rentry](https://rentry.org/) - Markdown pastebin service with preview, custom URLs, and editing, offering fast, simple, and free use with entries kept forever.
+- [Intab Resources](https://intab.io/resources/) - Curated Web Dev Tools 2021.
+- [Chrome Extension Kit](https://chromeextensionkit.com/) ($) - Kit including 17 battle-tested starter templates for building Chrome Extensions, saving time on setup and focusing on shipping.
+- [Esoteric Codes](https://esoteric.codes/) - Platform exploring esoteric programming languages (esolangs), constraint-based coding, code art, code poetry, and more.
+- [FreeFormatter](https://freeformatter.com/) - Free online tools for developers, including formatters, validators, code minifiers, string escapers, encoders/decoders, message digesters, and more.
+- [dbdesigner.net](https://www.dbdesigner.net/) - Online database schema design and modeling tool for free.
+- [Jvns blog](https://jvns.ca/blog/2022/04/12/a-list-of-new-ish--command-line-tools/>) - A list of new(ish) command line tools
+- [VisBug](https://visbug.web.app/) - Open-source browser design tools for web development.
+- [Web Design Repo](https://webdesignrepo.com/) - Repository of free web design resources for designers and developers.
+- [Devopedia](https://devopedia.org/) - Knowledge hub covering various topics related to technology and software development.
+- [MadeWithBubble](https://www.madewithbubble.xyz/) - Platform to discover interesting apps and websites created with Bubble, a visual web development platform.
+- [Interneting is Hard](https://www.internetingishard.com/) - Friendly web development tutorials designed for complete beginners.
+- [Airtable Toolkit](https://www.airtable.com/home/toolkit) - Platform allowing users to build apps that connect different parts of their work, ensuring synchronization within the business.
+- [Grey Software Resources](https://resources.grey.software/) - Up-to-date software resources curated and crowd-sourced by professionals and academics worldwide.
+- [Free-for.dev](https://free-for.dev/#/) - List of software (SaaS, PaaS, IaaS, etc.) and other offerings that have free tiers for developers.
+- [Free Privacy Policy Generator](https://www.freeprivacypolicy.com/) - Tool to generate a free privacy policy, ensuring compliance with requirements from CCPA, GDPR, CalOPPA, Google Analytics & AdSense, and more.
+- [Mailinator](https://www.mailinator.com/) ($) - Platform allowing developers and QA testing teams to test email and SMS workflows, including 2FA verifications, sign-ups, and password resets.
+- [Addy's Toolkit](https://toolkit.addy.codes/) - Collection of 806 hand-picked tools & resources for web designers & developers.
+- [BrowserBench - Speedometer 3.0](https://www.browserbench.org/Speedometer3.0/) - A benchmark tool to measure the performance of web browsers, specifically testing responsiveness and the speed of modern web applications.
+- [UserAgents.me](https://www.useragents.me/) - Provides self-updating list of the latest and most common useragents seen on the web across all device types, operating systems, and browsers. Data is always fresh, updating weekly. This user agent list is perfect for web scrapers looking to blend in, developers, website administrators, and researchers. The most common useragents list is compiled from the user logs data of a number of popular sites across niches and geography, cleansed (bots removed), and enriched with information about the device and browser.
+
+### Domain Names
+
+- [Atlaq](https://atlaq.com/) - Domain name generator.
+- [ICANN Lookup](https://lookup.icann.org/en) - Registration data for domain names and Internet number resources accessed using WHOIS and RDAP protocols.
+
+### Front-end
+
+- [SafeRules](https://anthonyhobday.com/sideprojects/saferules/) - Visual design rules that can be safely followed every time.
+- [Can I Email](https://www.caniemail.com/) - Check email client compatibility for HTML and CSS features.
+- [Egg Gradients](https://www.eggradients.com/) - Collection of gradient background colors.
+- [Frontend Checklist](https://frontendchecklist.io/) - Exhaustive list of all elements you need to have/test before launching your website/HTML page to production.
+- [Frontend Mentor](https://www.frontendmentor.io/) - Platform to solve real-world HTML, CSS, and JavaScript challenges while working to professional designs.
+- [CodePen](https://codepen.io/) - Platform to build, test, and discover front-end code. Explore [topics](https://codepen.io/topics/).
+- [Electron](https://www.electronjs.org/) - Framework to build cross-platform desktop apps with JavaScript, HTML, and CSS.
+- [Homepage Gallery](https://homepage.gallery/) - Gallery featuring 500+ websites for web design inspiration.
+- [HTML Dog](https://htmldog.com/) - Comprehensive resource on HTML, CSS, and JavaScript.
+- [Learn.shayhowe](https://learn.shayhowe.com/) - Learn to code HTML and CSS.
+- [This vs That](https://thisthat.dev/) - Explore the differences between concepts in front-end development.
+- [Know-It-All](https://know-it-all.io/) - List of what you know and what you don't know about web development.
+- [You Might Not Need jQuery](https://youmightnotneedjquery.com/) - jQuery alternatives.
+
+#### HTML
+
+- [Hyperscript](https://hyperscript.org/) - Make websites written in plain-old markup a joy to use.
+- [htmx](https://htmx.org/) - htmx gives you access to AJAX, CSS Transitions, WebSockets, and Server Sent Events directly in HTML, using attributes, so you can build modern user interfaces with the simplicity and power of hypertext.
+
+#### CSS
+
+- [CSS Solid](https://www.csssolid.com/) - CSS references, tutorials, and articles.
+- [CSS-Tricks](https://css-tricks.com/) - Web design community powered by Digital Ocean.
+- [CSS Box Shadow Code Snippet](https://onaircode.com/css-box-shadow-code-snippet/) - Code snippet for creating CSS box shadows.
+
+#### JavaScript
+
+- [The Coding Cards](https://thecodingcards.com/) ($) - JavaScript & Data Structures Flashcards. Essential Coding Concepts with Syntax and Examples.
+- [StandardJS](https://standardjs.com/) - JavaScript style guide, linter, and formatter.
+- [Modern JavaScript Cheatsheet](https://mbeaudru.github.io/modern-js-cheatsheet/) - A cheatsheet for the JavaScript knowledge you will frequently encounter in modern projects.
+- [JSONPlaceholder](https://jsonplaceholder.typicode.com/) - A free fake API for testing and prototyping.
+- [Vue.js Cheat Sheet](https://marozed.com/vue-cheatsheet/) - Cheat sheet for Vue.js.
+- [JS Bin](https://jsbin.com/) - Open-source collaborative web development debugging tool.
+- [JavaScript Event Keycode Info](https://www.toptal.com/developers/keycode) - Information about JavaScript event keycodes.
+- [jsDelivr](https://www.jsdelivr.com/) - Free CDN for open source. Fast, reliable, and automated.
+
+### Back-End
+
+- [RunSidekick](https://www.runsidekick.com/) - Collect traces and generate logs on-demand without stopping & redeploying your applications.
+- [Vantage Instances](https://instances.vantage.sh/) - Compare Amazon's instance types, pricing, and other pages.
+
+#### APIs
+
+- [Public APIs Directory](https://publicapis.dev/) - Discover public APIs
+- [Public APIs on GitHub](https://github.com/public-apis/public-apis) - Collective list of free APIs for use in software and web development
+- [REST API Tutorial](https://www.restapitutorial.com/) - Learn REST
+- [Spotify API Documentation](https://developer.spotify.com/documentation/web-api) - API documentation of Spotify
+- [Stripe API Documentation](https://stripe.com/docs/api) - API documentation of Stripe
+
+#### SQL
+
+- [SQLZoo](https://sqlzoo.net/wiki/SQL_Tutorial) - Learn SQL in stages
+- [Bipp SQL Tutorial](https://bipp.io/sql-tutorial) - Free SQL tutorial
+- [Select Star SQL](https://selectstarsql.com/) - Interactive book for learning SQL
+- [Medium-Hard Data Analyst SQL Interview Questions](https://quip.com/2gwZArKuWk7W) - Collection of SQL interview questions
+- [SQL Translate](https://www.sqltranslate.app/) - SQL to Natural Language and Natural Language to SQL translator. 100% free and open source
+- [Servers for Hackers](https://serversforhackers.com/) - Server Admin for Programmers. Learn server tech for development and production.
+- [SQLable](https://sqlable.com/) - Collection of SQL tools
+
+### Web Analytics
+
+- [Plausible Analytics](https://plausible.io/) - Simple, open source, lightweight and privacy-friendly alternative to Google Analytics
+- [Pirsch](https://pirsch.io/) - An open-source, cookie-free web analytics platform.
+- [Websites Milonic](https://websites.milonic.com/) - Provides neatly reported important data for websites.
+- [WooRank](https://www.woorank.com/) ($) - Website review and SEO checker.
+- [Semji](https://semji.com/) - A platform to improve the ROI of your content by creating high-performing SEO content.
+- [Web.dev](https://web.dev/) - Allows you to measure the performance of your website and provides actionable insights.
+- [Download Time Calculator](https://downloadtimecalculator.com/) - Estimates the time required to download any file based on your transfer speed without actually downloading the file.
+- [W3C Link Checker](https://validator.w3.org/checklink) - Checks links and anchors in web pages or full websites.
+- [URLVoid](https://www.urlvoid.com/) - A website reputation/safety checker, helping detect potentially malicious websites.
+- [SimilarSites](https://www.similarsites.com/) - Helps find similar websites and provides information about their statistics.
+- [LocaBrowser](https://www.locabrowser.com/) - Test how your website looks from different countries in real time.
+- [StatusVista](https://statusvista.com/) - An all-in-one status page for the systems your product depends on.
+- [BuiltWith](https://builtwith.com/) - Discover what technologies websites are built with, using a database of 59,905+ web technologies and over 673 million websites.
+- [CamelCamelCamel](https://camelcamelcamel.com/) - Free Amazon price tracker that monitors millions of products and alerts you when prices drop.
+- [CloudPing](https://cloudping.bastionhost.org/en/) - Perform an HTTP ping to measure network latency from your browser to various cloud data centers around the world.
+- [DownForEveryoneOrJustMe](https://downforeveryoneorjustme.com/) - Check if a website is down.
+- [DownDetector](https://downdetector.in/) - Real-time problem and outage monitoring.
+- [WebhookWizard](https://webhookwizard.com/) - Unlock data with webhooks.
+- [Lighthouse](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk?hl=en) - An open-source, automated tool for improving the performance, quality, and correctness of web apps.
+- [Archive.md](https://archive.md/) - A time capsule for web pages.
+- [Hypothesis](https://web.hypothes.is/) - A conversation layer over the entire web, working everywhere without needing implementation by any underlying site (open community project).
+- [keyword trends ai](https://keywordtrendsai.com/) - AI analysis of popular search keywords.
+
+#### Testing
+
+- [Fast.com](https://fast.com/) - Measures your internet speed, latency, and upload speed.
+- [Pingdom Tools](https://tools.pingdom.com/) ($) - Allows you to test the page load time, analyze it, and find bottlenecks.
+- [GTmetrix](https://gtmetrix.com/) - Analyze how your site performs, identify reasons for slowness, and discover optimization opportunities.
+- [Loader.io](https://loader.io/) - Free load testing service to stress test web apps and APIs with thousands of concurrent connections.
+- [WebPageTest](https://www.webpagetest.org/) - Measure your site's carbon footprint and run No-Code Experiments to find ways to improve.
+- [Azure Speed Test](https://www.azurespeed.com/Azure/Latency) - Tools for testing the speed and latency of Azure services.
+
+## Software Engineering
+
+- [NoviceDock](https://novicedock.com/) - Platform that provides resources and explanations across various software engineering areas.
+- [Morioh](https://morioh.com/) - Social network for developers to discuss topics about bugs and issues, share knowledge and connect the talents of millions of programmers and developers around the world.
+- [Algorithmica - High-Performance Computing](https://en.algorithmica.org/hpc/) - Algorithms for Modern Hardware by Sergey Slotin.
+- [ExBook](https://markm208.github.io/exbook/) - An Animated Introduction to Elixir.
+- [Ben Grosser Projects](https://bengrosser.com/projects/) - Portfolio of projects by Ben Grosser.
+- [Cybercademy Project Ideas](https://cybercademy.org/project-ideas/) - Resource for exploring cybersecurity project ideas, providing inspiration for educational or practical cybersecurity initiatives.
+
+### Android Development
+
+- [Fossdroid](https://fossdroid.com/) - A platform for discovering and sharing open-source Android apps.
+- [Android Weekly](https://androidweekly.net/) - A weekly newsletter with curated news, articles, and resources related to Android development.
+- [F-Droid Repository Search](https://apt.izzysoft.de/fdroid/index.php) - Allows you to search for apps available on the F-Droid repository, a collection of free and open-source Android apps.
+- [Exodus Privacy](https://reports.exodus-privacy.eu.org/en/) - Helps check permissions and trackers of Android apps, providing insights into the privacy aspects of different applications.
+- [Don't Kill My App](https://dontkillmyapp.com/) - A website advocating against aggressive app background process limitations on Android, which can negatively impact app performance.
+- [Mobile X Files](https://mobilexfiles.com/) - Smartphones' secret codes and other hidden functions.
+- [MobileRead Wiki](https://wiki.mobileread.com/wiki/Main_Page) - A comprehensive resource for eReaders, eBooks, and related technologies, providing guides, FAQs, and tutorials for users of various mobile reading devices.
+
+### Game Development
+
+- [itch.io](https://itch.io/) - A platform that provides a simple way to find and share indie games online for free.
+- [System Requirements Lab](https://www.systemrequirementslab.com/cyri) - Analyzes your computer's specifications in seconds, providing information on whether your system meets the requirements for various games.
+- [Kenney](https://kenney.nl/) - Platform offering free game assets, graphics, and game development resources.
+- [Flash Games Archive](https://flasharch.com/en) - Archive of Flash games, preserving these classic games for future enjoyment.
+- [OpenGameArt](https://opengameart.org/) - A platform offering free-to-use game assets, including 2D and 3D art, sound effects, and music for developers and game creators.
+- [Nexus Mods](https://www.nexusmods.com/) - One of the largest online communities for game modifications, offering a vast collection of mods for popular video games to enhance gameplay, add content, or personalize experiences.
+
+#### Game Theory
+
+- [Ncase](https://ncase.me/) - Game Theory explanations with simple games.
+- [Alberta Games Research](https://webdocs.cs.ualberta.ca/~games/) - A site from the University of Alberta offering resources and research related to game theory, computational models, and games as a computational study.
+- [Combinatorics.org](https://www.combinatorics.org/) - A. S. Fraenkel's bibliography of combinatorial game theory literature.
+- [Geometry and Graph Theory](https://ics.uci.edu/~eppstein/cgt/) - A resource on Combinatorial Game Theory, featuring explanations, examples, and research on algorithms for combinatorial problems.
+
+#### Games
+
+- [Bento Blocks Game](https://www.bentoblocksgame.com/) - Arrange ingredients in the bento box
+
+##### Pokemon
+
+- [Pokemon Database](https://pokemondb.net/) - A comprehensive Pokémon database with news and updates.
+- [Serebii](https://serebii.net/) - Offers various news, features, archives, and explanations about Pokémon.
+
+##### Chess
+
+- [The Chess Website](https://www.thechesswebsite.com/) - Learn, Practice, and Play Chess.
+- [Lichess](https://en.lichess.org/) - Free/libre, open-source chess server powered by volunteers and donations.
+- [Chess.com](https://www.chess.com/) - Online platform for online chess.
+
+### Embeddings
+
+- [FPGA4Fun](https://www.fpga4fun.com/) - Educational resources and tutorials focused on FPGA (Field-Programmable Gate Array) technology, providing practical guides for both beginners and advanced users.
+- [Wokwi](https://wokwi.com/) - Online ESP32, STM32, Arduino simulator.
+- [x86 Instruction Set Reference](https://c9x.me/x86/) - A mirror of the "Into the Void" reference for the x86 instruction set, providing a detailed guide to assembly language and processor instructions for x86 architecture.
+- [Analog Devices Wiki](https://wiki.analog.com/) - Knowledge base with technical documentation, tutorials, and resources on analog and mixed-signal devices, aimed at engineers and developers.
+- [IEEE-754 Floating Point Converter](https://www.h-schmidt.net/FloatConverter/IEEE754.html) - Tool to convert between the decimal representation of a number and the binary format used by modern CPUs, based on IEEE-754 standard.
+- [Guide to x86 Assembly](https://www.cs.virginia.edu/~evans/cs216/guides/x86.html) - Guide to x86 Assembly by University of Virginia Computer Science
+
+### Linux
+
+- [Linux Journey](https://linuxjourney.com/) - Platform for learning Linux.
+- [Run Linux in Your Browser](https://bellard.org/jslinux/) - Run Linux or other operating systems in your browser.
+- [OS Directory](https://os.directory/) - Platform that emulates a Linux distribution in your web browser.
+- [DistroWatch](https://distrowatch.com/) - Resource for Linux and BSD distributions, providing news, reviews, and comparisons to help users find and install the right operating system.
+- [SS64](https://ss64.com/) - Reference guide containing syntax and examples for the most prevalent computing commands, covering databases and operating systems.
+- [SS64 Bash Keyboard Shortcuts](https://ss64.com/bash/syntax-keyboard.html) - Reference guide for bash keyboard shortcuts.
+- [Command Line for Beginners](https://ubuntu.com/tutorials/command-line-for-beginners#1-overview) - Overview of the Linux command line for beginners.
+- [Linux Journey](https://linuxjourney.com/) - An educational website offering free, interactive lessons on Linux, covering everything from basic commands to advanced system administration.
+- [ExplainShell](https://explainshell.com/) - A tool for explaining Linux shell commands, providing detailed breakdowns of command syntax and function.
+- [LibreHunt](https://librehunt.org/) - Aid you on your Linux Distro (and potentially, Libre) hunt. Answer easy questions to get recommendations on which Linux distribution that meets your needs based on those responses.
+
+### Vim
+
+- [Vim Cheat Sheet](https://vim.rtorr.com/) - Vim cheat sheet.
+- [Learn Vim](https://learnvim.irian.to/) - A resource to learn Vim, the smart way.
+- [Vim Awesome](https://vimawesome.com/) - Search through listed Vim plugins
+- [Vim Adventures](https://vim-adventures.com/) - An interactive game designed to teach users the fundamentals of the Vim text editor through engaging puzzles and challenges.
+- [Vimified](https://www.vimified.com/) - Platform for learning and practicing Vim, a free and open-source, screen-based text editor program.
+
+### Git
+
+- [Git - The Simple Guide](https://rogerdudler.github.io/git-guide/) - A straightforward guide for getting started with Git.
+- [Git Sheet](https://gitsheet.wtf) - A quick reference guide for common Git commands.
+- [MiXLab on Google Colab](https://colab.research.google.com/github/shirooo39/MiXLab/blob/master/MiXLab.ipynb#scrollTo=e-0yDs4C0HkB) - A mixture of Google Colab notebooks compiled from GitHub.
+- [Learn Git Branching](https://learngitbranching.js.org/) - Interactive tool to learn Git branching through simulation of a git repository.
+
+### GitHub
+
+- [GitStalk](https://gitstalk.netlify.app/) - Platform to discover what individuals are working on in the GitHub community.
+- [GitExplorer](https://gitexplorer.com/) - Tool to find the right Git commands without searching through the web.
+- [GitStats](https://gitstats.me/) - Open-source GitHub contribution analyzer that provides insights into your GitHub activity.
+- [Gitcoin](https://gitcoin.co/) - Platform where individuals can get paid for contributing to open-source software in various programming languages and domains.
+- [Oh Shit, Git!](https://ohshitgit.com/) - Resource providing solutions for common Git mistakes and how to recover from them.
+- [GitHub Trending Archive](https://github.motakasoft.com/trending/) - Archive of trending repositories on GitHub, allowing users to explore popular projects and programming trends over time.
+- [Map of GitHub](https://anvaka.github.io/map-of-github/) - Visual representation of the GitHub repository network.
+
+### IDEs
+
+- [OneLang IDE](https://ide.onelang.io/) - Online tool for converting code from one programming language to another.
+- [Theia IDE](https://theia-ide.org/) - Flexible and extensible cloud and desktop IDE platform, enabling efficient development and delivery of IDEs and tools using modern web technologies.
+- [VSCode Themes](https://vscodethemes.com/) - A platform offering a wide variety of themes for Visual Studio Code, allowing users to personalize the look and feel of their coding environment with different color schemes and styles.
+
+## Privacy
+
+- [ToS;DR](https://tosdr.org/) - Terms of Service; Didn't Read (short: ToS;DR).
+- [Nothing Private](https://www.nothingprivate.ml/) - Check why you are not anonymous when using private browsing mode or incognito mode. You can also read it [here](https://github.com/gautamkrishnar/nothing-private).
+- [TrustPage](https://trustpage.com/directory) - Find and compare security policies for thousands of companies to choose the right software and services based on security policies sourced from around the web.
+- [Arkenfox User.js](https://github.com/arkenfox/user.js/wiki/4.1-Extensions) - Privacy and security-related browser extensions.
+- [Cookiepedia](https://cookiepedia.co.uk/) - The largest database of pre-categorized cookies and online tracking technologies.
+- [Security Planner](https://securityplanner.consumerreports.org/) - Get customized recommendations to cut down on data collection and prevent hacking.
+- [MyWhisper](https://mywhisper.net/) - A text encryption tool based on AES cryptography.
+- [BeEncrypted](https://beencrypted.com/) - Resources to become more encrypted.
+- [Prism Break](https://prism-break.org/en/all/) - Private and safe alternatives to the most used apps and services.
+- [Reddit Piracy Megathread](https://www.reddit.com/r/piracy/wiki/megathread/tools) - A list of apps, tools, and web services.
+- [Ressources](https://gitlab.com/tzkuat/Ressources) - List of websites on different areas such as security, OSINT, etc.
+- [Privacy Tools List by CHEF-KOCH](https://chef-koch.bearblog.dev/privacy-tools-list-by-chef-koch/) - A comprehensive list of privacy tools.
+- [Privacy Analyzer](https://privacy.net/analyzer/#pre-load) - Analyze privacy settings for websites.
+- [Shut Up Trackers](https://shutuptrackers.com/) - Provides information for protecting your data security and privacy.
+- [EFF Surveillance Self-Defense](https://ssd.eff.org/) - Tips, tools, and how-tos for safer online communications.
+- [Router Passwords](https://www.routerpasswords.com/) - The most updated default router password repository on the internet.
+- [BugMeNot](https://bugmenot.com/) - Find and share logins for various websites.
+- [Security.org](https://www.security.org/security-score/) - Learn about your security score.
+- [LibreProjects](https://libreprojects.net/#favs=wikipedia,joindiaspora-com,nextcloud,openstreetmap,jamendo,plos) - A list of 118 open-source hosted web services.
+- [Privnote](https://privnote.com/) - Send notes that will self-destruct after being read.
+- [Dangerzone](https://dangerzone.rocks/) - Platform for converting potentially unsafe PDFs, Office documents, or images into safe, viewable formats.
+- [ExifTool](https://exiftool.org/) - Software for reading, writing, and editing metadata in image, audio, and video files.
+- [HideMyWeb](https://hidemyweb.wordpress.com/) - Tool to hide, blur, and highlight content on web pages.
+- [Browser.lol](https://browser.lol/) - Browse anonymously with a free virtual environment within your browser.
+- [OneTimeSecret](https://onetimesecret.com/) - Platform for sharing a password, secret message or private link securely with one-time links.
+- [MetaDefender](https://metadefender.opswat.com/) - Online tool for scanning and analyzing files for security threats, providing detailed reports on potential risks.
+- [FotoForensics](https://fotoforensics.com/) - Online tool for analyzing and verifying digital images, providing forensic tools to detect alterations and edits in photos.
+
+### Cryptography
+
+- [Cryptologie](https://www.cryptologie.net/) - A website covering various topics in cryptography.
+- [Invisible](https://mikebradley.me/invisible/index.html) - A tool that hides text in images and allows you to find hidden text.
+
+### GAFA Alternatives
+
+- [DeGoogle](https://degoogle.jmoore.dev/#mobile-applications-mobile-apps-installable-from-stores) - Huge list of alternatives to Google products. Privacy tips, tricks, and links.
+- [Degooglisons Internet](https://degooglisons-internet.org/en/) - Alternatives to FAANG.
+- [AccountKiller](https://www.accountkiller.com/en/home) - AccountKiller collects direct links and deleting instructions to make account termination easy.
+- [JustDeleteMe](https://backgroundchecks.org/justdeleteme/) - A directory of direct links to delete your account from web services.
+- [SmartTubeNext](https://github.com/yuliskov/SmartTubeNext) - Ad-free app for watching YouTube videos on Android TV boxes.
+- [Libredirect](https://libredirect.github.io/) - Web extension that redirects YouTube, Twitter, Instagram requests to alternative privacy-friendly frontends and backends.
+
+### Ad Blocker
+
+- [Adblock Tester](https://adblock-tester.com/) - Tool to check the effectiveness of your AdBlock extensions.
+- [12ft](https://12ft.io/) - Remove paywalls and gain access to articles.
+- [Incoggo](https://incoggo.com/) - Adblocker for paywalls.
+
+### Emails
+
+- [BurnerMail](https://burnermail.io/) - Protect your personal email address, control who can send you emails, and generate new burner addresses with one click.
+- [Kill the Newsletter](https://kill-the-newsletter.com/) - Transform email newsletters into Atom feeds for easier consumption.
+- [Dead Man's Switch](https://www.deadmansswitch.net/) - A service that sends your emails to your designated recipients if you don't interact with it within a specified timeframe.
+- [YAMM](https://yamm.com/) ($) - Mail merge for Gmail, allowing you to send mass emails with Gmail, ensuring delivery to the primary inbox. Track results in real-time directly from Google Sheets.
+
+#### Disposable Email
+
+- [Erine Email](https://erine.email/) - An anti-spam service for your existing email address.
+- [Maildrop](https://maildrop.cc/) - Use Maildrop when you don't want to give out your real email address.
+- [Mailsac](https://mailsac.com/) - Offers disposable email services for testing and development purposes.
+- [InboxKitten](https://inboxkitten.com/) - An open-source disposable email service.
+- [Guerrilla Mail](https://www.guerrillamail.com/inbox) - Allows you to compose emails and determine the domain, master passphrase, and password of your disposable email.
+- [EmailDrop](https://www.emaildrop.io/) - Enables you to create emails with custom or random domains in a highly minimalistic design.
+- [GetNada](https://getnada.com/) - Provides temporary email addresses.
+- [GetNotify](https://www.getnotify.com/) - A free email tracking service that notifies you when the emails you send are read.
+- [MXToolbox](https://mxtoolbox.com/) - Offers free DNS and email tools in a single place for streamlined troubleshooting.
+- [Postale](https://postale.io/) ($) - Allows you to create domain email addresses effortlessly in minutes.
+
+### Data Breach
+
+- [Have I Been Pwned](https://haveibeenpwned.com/) - Check if your email or phone is in a data breach.
+- [TinEye](https://tineye.com/) - Find where images appear online.
+- [IPLeak](https://ipleak.net/) - See the kind of information that all the sites you visit can see and collect about you.
+- [Cover Your Tracks](https://coveryourtracks.eff.org/) - Test your browser to see how well you are protected from tracking and fingerprinting.
+- [Am I FLoCed](https://amifloced.org/) - Check if Google is testing FLoC on your Chrome browser.
+
+### Search
+
+- [Startpage](https://www.startpage.com/) - Get privacy protection across the web.
+- [Neeva](https://neeva.com/) - Ad-free, private search engine with a subscription model.
+- [AndiSearch](https://andisearch.com/) - Ad-free and anonymous search engine.
+- [Plex Page](https://plex.page/) - Search summarization tool.
+- [Marginalia Search](https://search.marginalia.nu/) - Independent DIY search engine focusing on non-commercial content.
+- [Unlisted Videos](https://unlistedvideos.com/) - For submitting, searching for, and watching unlisted YouTube videos. No registration required.
+- [Filmot](https://filmot.com/) - Search within YouTube subtitles.
+- [XN--1-ZFA](https://xn--1-zfa.com/) - Advanced search for Google, DuckDuckGo, Twitter, YouTube, Reddit.
+- [Seekr](https://www.seekr.com/) - Search engine that utilizes AI to analyze and score the quality of content, starting with news articles.
+- [Million Short](https://millionshort.com/) - Discover content beyond the first million search results.
+
+### Internet
+
+- [Internet Live Stats](https://www.internetlivestats.com/) - Provides real-time statistics about the internet, including the number of websites, emails, and more.
+- [Internet Map](https://internet-map.net/) - An interactive map that visually represents the internet, showing the relationships between various websites.
+- [Test IPv6](https://test-ipv6.com/) - Allows you to test your IPv6 connectivity and provides information about your network setup.
+- [TLS 1.2 Explained](https://tls12.xargs.org/) - Provides a detailed explanation of every byte in a TLS connection.
+- [CIDR.xyz](https://cidr.xyz/) - An interactive IP address and CIDR range visualizer.
+- [I Can Haz IP](https://icanhazip.com/) - Displays only your IP address at the top of the page.
+- [IP Location](https://iplocation.io/) - Provides free location tracking of an entered IP address, including city, country, latitude, and longitude.
+- [Ifconfig.co](https://ifconfig.co/) - Helps you find your own IP address and provides information about it.
+- [IPinfo.io](https://ipinfo.io/) - Offers accurate IP address data for various use cases.
+- [Visual Subnet Calculator](https://www.davidc.net/sites/default/subnets/subnets.html) - A visual subnet calculator to help with IP address and subnet calculations.
+- [Ping Test](https://www.meter.net/ping-test/) - Online tool to measure network latency by sending test packets (pings) to a specified server, providing insights into connection stability and speed.
+- [LibreSpeed](https://librespeed.org/) - Open-source internet speed test tool, offering accurate measurements of download, upload, and latency without requiring additional software installations.
+
+#### DNS
+
+- [How DNS Works](https://howdns.works/) - Offers a colorful explanation of how DNS works with the help of comics.
+- [DNS Checker](https://dnschecker.org/) - Provides a free DNS lookup service to check Domain Name System records against a selected list of DNS servers worldwide.
+- [AdGuard DNS Providers](https://kb.adguard.com/en/general/dns-providers) - A list of DNS providers that you can configure to use instead of the default provided by your router or ISP.
+- [DNS Speed Test](https://dnsspeedtest.online/) - Fast DNS server speed test tool, allowing users to find the most optimal DNS server for faster internet browsing with no installation required.
+
+### URL
+
+- [URL Tools](https://shrtco.de/tools/) - Various tools for URLs.
+- [OneLink](https://www.onelink.to/) - Platform for creating links and QR codes for your apps.
+- [QR Code Generator](https://freecodetools.org/qr-code-generator/) - Tool for generating QR codes.
+- [AppOpener](https://appopener.com/) - Create smart links to open desired apps from URLs without login.
+- [Who Is Hosting Any Domain](https://digital.com/best-web-hosting/who-is/) - Find out who is hosting any domain, including web host, IP address, name servers, and more.
+- [Webhook.Site](https://webhook.site/) - Platform to inspect, test, and automate any incoming HTTP request or email.
+- [GoQR.Me](https://goqr.me/) - Generator for high-resolution QR codes suitable for print.
+- [Open Graph Generator](https://freecodetools.org/ogp/) - Tool for generating Open Graph images.
+
+#### URL Shortener
+
+- [Rebrandly](https://www.rebrandly.com/) - A link management platform to brand, track, and share short URLs using a custom domain name.
+- [Bit.do](https://bit.do/) - Provides real-time traffic statistics for your links for free.
+- [s.id](https://home.s.id/) - Link shortener and microsite builder.
+- [TinyURL](https://tinyurl.com/app) - Offers optional short link endings.
+- [Tiny.cc](https://tiny.cc/) - Offers optional short link endings.
+- [Bitly](https://bitly.com/) - Web/mobile link management and campaign management analytics as well as branded links.
+- [iplogger.org](https://iplogger.org/) - URL shortener with advanced analytics for the traffic through your links, visitors on your online store, blog, or website.
+- [cutr.ml](https://cutr.ml/) - URL shortener.
+- [is.gd](https://is.gd/) - URL shortener.
+- [gg.gg](https://gg.gg/) - URL shortener.
+- [shrunken.com](https://www.shrunken.com/) - URL shortener.
+
+### Password Generation
+
+- [Everything About Passwords and Internet Security](https://www.healthypasswords.com/index-2.html) - Comprehensive information on passwords and internet security.
+- [Random Password Generator](https://random-password-gen.web.app/) - Generate random and secure passwords.
+- [How Secure Is My Password?](https://www.security.org/how-secure-is-my-password/) - Check the security strength of your password. Entries are secure and not stored or shared.
+- [Password Generator](https://freecodetools.org/password-generator/) - Generate secure passwords easily.
+
+## Softwares
+
+- [OlderGeeks](https://oldergeeks.com/) - Ad-free software download site supported by donations, providing a hassle-free experience.
+- [AlternativeTo](https://alternativeto.net/) - Discover the best alternatives to popular software based on user recommendations.
+- [Open Source Alternative](https://www.opensourcealternative.to/) - Platform providing open-source alternatives to proprietary software.
+- [Dark Mode List](https://darkmodelist.com/) - List of 300 apps that support dark mode.
+- [LocalStack](https://localstack.cloud/) - Develop and test cloud and serverless apps offline.
+- [Markwhen](https://markwhen.com/) - Text-to-timeline tool converting markdown-ish text into a cascading timeline.
+- [Asciinema](https://asciinema.org/) - Record and share your terminal sessions with a purely text-based approach.
+- [Apache Guacamole](https://guacamole.apache.org/) - Clientless remote desktop gateway supporting protocols like VNC, RDP, and SSH.
+- [DockerSwarm.rocks](https://dockerswarm.rocks/) - Deploy your application stacks to production in a distributed cluster using Docker Compose files.
+- [EasyCron](https://www.easycron.com/) - Online cron job service (Paid).
+- [CDecl](https://cdecl.org/) - Translate C gibberish to English, helping you understand complex C declarations.
+- [NirSoft](https://www.nirsoft.net/) - Collection of small utilities for Windows, including system tools, password recovery tools, and more.
+- [Ninite](https://ninite.com/) - Install and update multiple programs at once without toolbars or unnecessary clicks.
+- [ReadWok](https://app.readwok.com/lib) - Online text reader with a progressive viewing mode, allowing paragraph-by-paragraph reading and editing.
+- [BitwiseCMD](https://bitwisecmd.com/) - Online bitwise operations and conversions.
+- [Commands.dev](https://www.commands.dev/?ref=producthunt) - Searchable, templated catalog of popular terminal commands curated from across the internet.
+- [SourceForge](https://sourceforge.net/) - Web-based service that allows you to compare, download and develop open source and business software.
+
+### Snippets
+
+- [CodeClippet](https://codeclippet.com/) - Platform for sharing code snippets within a community-focused environment.
+- [Kod.so](https://kod.so/) - Platform for creating visual snippets, with the ability to download and share them.
+- [CodePNG](https://www.codepng.app/) - Tool for creating pictures from source code by converting code into images.
+- [CodeMyUI](https://codemyui.com/) - Website providing web design and UI inspiration with curated code snippets.
+- [30 Seconds of Code](https://www.30secondsofcode.org/list/p/1) - Curated collection of short code snippets for various development needs.
+- [W3Schools HowTo](https://www.w3schools.com/howto/default.asp) - W3Schools section offering code snippets for HTML, CSS, and JavaScript.
+- [Snipplr](https://snipplr.com/) - Platform for keeping frequently used code snippets in one accessible place, allowing users to share and discover code snippets.
+- [LittleSnippets](https://littlesnippets.net/) - Platform for sharing and discovering small code snippets.
+- [CodeToGo](https://codetogo.io/) - Resource to find up-to-date snippets for JavaScript and React use cases.
+- [TweetSnippet](https://tweetsnippet.com/) - Curated list of tips and tricks from Twitter, presented in code snippet form.
+- [CSS-Tricks Snippets](https://css-tricks.com/snippets/) - Collection of CSS snippets covering various design and layout techniques.
+- [Crontab Guru](https://crontab.guru/) - Quick and simple editor for cron schedule expressions, providing human-readable explanations.
+- [Crontab Generator](https://crontab-generator.org/) - Online tool to generate cron schedule expressions with a user-friendly interface.
+- [Carbon](https://carbon.now.sh/) - Web-based tool for creating and sharing beautiful images of source code snippets with syntax highlighting.
+
+### Linters
+
+- [FromLatest.io](https://www.fromlatest.io/#/) - Dockerfile linter for checking the syntax and best practices in Dockerfiles.
+- [YAMLlint](https://www.yamllint.com/) - Online tool to check the validity of YAML code and provide a clean UTF-8 version optimized for Ruby.
+- [K8sYaml](https://k8syaml.com/) - Kubernetes YAML Generator for creating Kubernetes configuration files.
+- [Puppet Validator](https://validate.puppet.com/) - Tool to check the validity of Puppet code syntax without compiling or enforcing a catalog.
+- [ShellCheck](https://www.shellcheck.net/) - Online platform for finding bugs in shell scripts by analyzing and providing suggestions for improvement.
+- [Beautifier.io](https://beautifier.io/) - Online tool to beautify, unpack, or deobfuscate JavaScript and HTML, and make JSON/JSONP readable.
+- [JSONLint](https://jsonlint.com/) - Validator and reformatter for JSON, providing tidying and validation for messy JSON code.
+- [Algorithm Visualizer](https://algorithm-visualizer.org/) - Interactive platform that visualizes algorithms from code to help understand their execution.
+- [CodeBeautify](https://codebeautify.org/) - Online platform offering code formatting tools, including JSON beautifier, XML viewer, hex converters, and more.
+- [ExplainShell](https://explainshell.com/) - Tool to explain command-line commands by displaying the help text for each argument.
+- [ShowTheDocs](https://showthedocs.com/) - Documentation browser that finds relevant docs for your code, making it easier to explore and understand.
+- [Mango - Specification Interpretation](https://mango-slra1-ckwssph7iq-ue.a.run.app/readme) - Technique to interpret specifications and automatically identify defects such as logical contradictions, over-complexity, and inconsistency of entity names.
+- [Code Minifier](https://freecodetools.org/minifier/) - Online tool for minifying code to reduce file size and improve load times.
+- [Markdown Preview](https://freecodetools.org/markdown-preview/) - Online tool for previewing and formatting Markdown text.
+- [Code Beautifier](https://freecodetools.org/beautifier/) - Online tool for beautifying and formatting code for improved readability.
+- [CodePad](https://codepad.org/) - Online compiler/interpreter and collaboration tool, allowing users to run and share code snippets with a short URL.
+- [JSON Formatter](https://jsonformatter.org/json-parser) - Online JSON parser and formatter.
+- [SQL Formatter](https://formatjsononline.com/sql-formatter) - Free Online SQL Formatter & Beautifier.
+
+### Testing
+
+- [OWASP Fuzzing Project](https://owasp.org/www-community/Fuzzing) - The official page for the OWASP Fuzzing Project, which aims to improve the overall state of fuzzing tools, techniques, and processes.
+- [Awesome Fuzzing](https://github.com/secfigo/Awesome-Fuzzing) - A curated list of fuzzing resources, including tools, tutorials, research papers, and more.
+
+### Regex
+
+- [Regex Cheat Sheet](https://dev.to/emmabostian/regex-cheat-sheet-2j2a) - A helpful guide for regular expressions.
+- [RegExr](https://regexr.com/) - An online tool to learn, build, and test Regular Expressions (RegEx/RegExp).
+- [Regulex](https://jex.im/regulex/) - JavaScript Regular Expression Visualizer for understanding and visualizing regular expressions.
+- [Regex101](https://regex101.com/) - An online regex tester and debugger.
+- [Debuggex](https://www.debuggex.com/) - A visual regex tester that allows you to understand how your regular expression works.
+- [UI Bakery Regex Library](https://uibakery.io/regex-library/) - Collection of regular expressions for UI design.
+- [Pyrexp](https://pythonium.net/regex) - An online visual regex tester for Python.
+
+### No-Code
+
+- [No Code List](https://nocodelist.co/) - Browse categories to discover over 300 no-code tools.
+- [No-Code Things](https://www.spacebarcounter.net/no-code-tools) - A collection of no-code tools.
+
+#### Licensing
+
+- [ChooseALicense - Appendix](https://choosealicense.com/appendix/) - Additional information and resources related to open source licenses.
+- [GitHub Docs - Licensing a Repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) - GitHub's documentation on licensing a repository.
+- [Public License Selector](https://ufal.github.io/public-license-selector/) - Helps you choose an open source license based on your preferences.
+- [Creative Commons License Chooser](https://creativecommons.org/choose/) - Choose a Creative Commons license that suits your content sharing preferences.
+- [License Buttons](https://licensebuttons.net/) - Get buttons for your website that indicate the license terms of your content.
+- [Shields.io](https://shields.io/) - Create custom badges (shields) for your GitHub repositories, providing information like license, version, and more.
+
+## Programming Languages
+
+- [EbookFoundation-Free-Programming-Books](https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-langs.md) - Free and open source programming books
+- [Codecademy Catalog](https://www.codecademy.com/catalog) - Platform offering a catalog of courses for learning various programming languages and technologies.
+- [Learn X in Y Minutes](https://learnxinyminutes.com/) - Resource providing a quick whirlwind tour of various programming languages.
+- [eComputerNotes](https://ecomputernotes.com/) - Learning resource for online education, covering a wide range of computer science and programming topics.
+- [Libraries.io](https://libraries.io/) - Platform to discover new open-source packages, modules, and frameworks, and keep track of dependencies.
+- [LearnByExample](https://www.learnbyexample.org/) - Platform to learn Python, SQL, and R languages with examples and practical explanations.
+- [PythonTutor](https://pythontutor.com/) - Tool that helps users learn Python, JavaScript, C, C++, and Java programming by visualizing code execution step by step.
+- [Classic Papers in Programming Languages and Logic](https://www.cs.cmu.edu/~crary/819-f09/) - Collection of seminal academic papers on programming languages and logic, curated by Carnegie Mellon University.
+- [RubyGems Guides](https://guides.rubygems.org/) - Learn how RubyGems works and how to make your own
+
+### Haskell
+
+- [Learn You a Haskell for Great Good!](https://learnyouahaskell.github.io/chapters.html) - Online book version of "Learn You a Haskell" by by Miran Lipovača.
+- [Real World Haskell](https://book.realworldhaskell.org/read/) - Online book version of "Real World Haskell" by Bryan O'Sullivan, Don Stewart, and John Goerzen.
+- [CIS 194 - Introduction to Haskell (Spring 2013)](https://www.seas.upenn.edu/~cis1940/spring13/lectures.html) - Lecture materials and resources on Haskell programming.
+- [GitHub - Programming in Haskell](https://github.com/topics/programming-in-haskell) - Collection of Haskell-related repositories and projects on GitHub.
+
+### Python
+
+- [Python Documentation](https://docs.python.org/3/) - Official documentation for the Python programming language.
+- [Python Wiki](https://wiki.python.org/moin/FrontPage) - Collaborative platform providing information and resources related to Python.
+- [Awesome Python](https://awesome-python.com/) - Curated list of awesome Python frameworks, libraries, software, and resources.
+- [Project Python](https://projectpython.net/) - Platform offering Python tutorials and resources for learning and development.
+- [Learn Python](https://www.learnpython.org/) - Interactive platform providing tutorials and exercises to learn Python programming.
+- [CSCircles](https://cscircles.cemc.uwaterloo.ca/) - Online platform offering interactive Python exercises and resources, developed by the University of Waterloo.
+- [PythonBasics](https://pythonbasics.org/) - Website providing resources and tutorials for learning Python basics.
+- [Majyori](https://www.majyori.com/) - Platform offering Python tutorials and resources for learners of all levels.
+- [PyFormat](https://pyformat.info/) - Website comparing Python formatting styles with examples from different versions.
+- [Learn by Example - Python Resources](https://learnbyexample.github.io/py_resources/) - Collection of Python resources and tutorials for various topics.
+- [Data to Fish](https://datatofish.com/python-tutorials/) - Platform offering clear Python tutorials covering topics such as machine learning, databases, pandas, GUI, and more.
+- [Notion Programming Course](https://www.notion.so/Programming-Course-4d4331de1a0c4ae894133cb1ca1e9315) - Self-study course for learning to build basic web applications in Django, hosted on Notion.
+
+### C++
+
+[LearnCpp.com](https://www.learncpp.com/) - A comprehensive resource for learning C++ programming.
+
+## Coding Practice / Competitive Programming
+
+- [LeetCode](https://leetcode.com/) - Platform for practicing coding problems with a focus on algorithmic challenges.
+- [NeetCode](https://neetcode.io/) - Coding practice website designed to enhance your skills through real-world projects and collaborative coding.
+- [HackerRank](https://www.hackerrank.com/dashboard) - Coding platform offering challenges in various domains, from algorithms to artificial intelligence.
+- [CodeWars](https://www.codewars.com/) - Community-driven platform providing coding challenges with a focus on improving through peer-reviewed solutions.
+- [Project Euler](https://projecteuler.net/about) - Mathematics-oriented coding platform, featuring challenging problems to encourage problem-solving through programming.
+- [Kattis Guide](https://unh-cpc.github.io/kattisguide.html) - A guide to solving competitive programming problems using the Kattis platform, providing tips, problem-solving strategies, and resources for participants.
+- [Kaggle](https://www.kaggle.com/) - Data science platform that hosts competitions, datasets, and notebooks, fostering collaboration and innovation in the field.
+- [Replit](https://replit.com/) - Online coding environment facilitating collaborative coding, with features like live sharing and a wide range of supported languages.
+- [AlgoLeague](https://www.algoleague.com/) - Competitive programming platform for practicing algorithmic problem-solving.
+- [Codeforces](https://codeforces.com/) - Online competitive programming platform offering contests and a vast problem set, attracting a diverse international user base.
+- [AtCoder](https://atcoder.jp/) - Japanese competitive programming platform hosting contests and exercises to enhance algorithmic skills.
+- [InterviewBit](https://www.interviewbit.com/coding-interview-questions/) - Platform offering coding interview questions and challenges to help prepare for technical interviews.
+- [Advent of Code](https://adventofcode.com/) - Advent calendar of small programming puzzles suitable for various skill sets and levels, solvable in any programming language.
+- [CList](https://clist.by/) - List of competitions from various programming websites, providing a centralized resource for upcoming contests.
+- [Codeply](https://www.codeply.com/) - Free online editor featuring dozens of frameworks, starter templates, and over 50,000 code snippets.
+- [URI Online Judge](https://www.urionlinejudge.com.br/judge/en/login) - Platform for training algorithms and programming challenges to enhance programming skills.
+- [Rosalind](https://rosalind.info/problems/locations/) - Platform for learning bioinformatics and programming through problem-solving.
+- [Kattis](https://open.kattis.com/) - Platform with hundreds of programming problems to solve, helping users practice and improve their coding skills.
+- [Exercism](https://exercism.org/tracks) - Platform for developing fluency in 67 programming languages through a unique blend of learning, practice, and mentoring, offered for free.
+- [Codility](https://codility.com/programmers/challenges) - Platform offering coding challenges to assess and improve algorithmic and problem-solving skills.
+- [r/dailyprogrammer](https://www.reddit.com/r/dailyprogrammer/) - Subreddit on Reddit featuring daily programming challenges and discussions for coding enthusiasts.
+- [Daily Coding Problem](https://www.dailycodingproblem.com/) - Service that sends daily coding challenges to subscribers to improve coding and problem-solving skills.
+- [Coderbyte](https://coderbyte.com/) - Platform with coding challenges and interview preparation resources to enhance programming skills.
+- [CodinGame](https://www.codingame.com/start) - Online platform gamifying coding challenges, making learning and practicing programming more engaging.
+- [A2OJ](https://a2oj.netlify.app/) - Competitive programming resource providing a structured ladder system to improve problem-solving skills, categorized by difficulty levels and topics.
+- [CodeChef](https://www.codechef.com/) - Competitive programming website with regular contests and a large problem archive, catering to a global coding community.
+- [USACO](http://usaco.org/index.php?page=contests) - USA Computing Olympiad platform, providing programming contests to encourage and identify talented young programmers in the United States.
+- [USACO Guide](https://usaco.guide/) - Comprehensive, free resource collection guiding users from Bronze to Platinum levels and beyond in competitive programming.
+- [JoinCPI](https://joincpi.org/) - Platform dedicated to promoting competitive programming among students through resources, classes, outreach, and contests.
+- [CP-Algorithms](https://cp-algorithms.com/) - Website providing a detailed guide to algorithms specifically tailored for competitive programming, offering in-depth explanations and examples.
+- [CSS Battle](https://cssbattle.dev/) - Platform challenging users to use CSS skills to replicate targets with the smallest possible code.
+- [JavaScript Quiz](https://javascriptquiz.com/) - Website offering quizzes focused on testing and enhancing knowledge of JavaScript programming language.
+- [Elevator Saga](https://play.elevatorsaga.com/) - Game for learning and practicing JavaScript.
+- [Deep ML](https://www.deep-ml.com/) - Website offering ML Code Challenges.
+- [Hack The Box](https://www.hackthebox.com/) - An online platform for hacking training, offering virtual environments and challenges to help individuals and organizations develop cybersecurity skills.
+
+### Capture the Flag
+
+- [CTF101](https://ctf101.org/) - Platform providing educational resources for those new to Capture The Flag competitions.
+- [CTFtime](https://ctftime.org/) - Archive of Capture The Flag events, teams, and timelines.
+- [Google CTF on GitHub](https://github.com/google/google-ctf) - Google's Capture The Flag competition resources available on GitHub.
+- [Meusec CTF Resources](https://www.meusec.com/ctf/capture-the-flags-in-cybersecurity/) - Meusec's collection of Capture The Flag (CTF) resources in cybersecurity.
+- [Trail of Bits - CTF Guide](https://trailofbits.github.io/ctf/) - Guide by Trail of Bits providing insights and tips for participating in Capture The Flag competitions.
+
+### Projects
+
+- [Projects-Solutions on GitHub](https://github.com/karan/Projects-Solutions) - GitHub repository providing project-based coding challenges for learning programming through practical applications.
+- [Build Your Own X](https://github.com/codecrafters-io/build-your-own-x#build-your-own-neural-network) - GitHub repository providing guides on building your favorite technologies from scratch.
+- [Arduino Project Hub](https://projecthub.arduino.cc/) - Hub for sharing and discovering Arduino projects.
+- [Projects in Networking](https://projectsinnetworking.com/) - Resource for networking projects, network security projects, cyber security case studies, and source code for students, graduates, and professionals in the computer networking and security domain.
+
+### Open Source
+
+- [LibHunt](https://www.libhunt.com/) - Platform for discovering trending open-source projects and their alternatives.
+- [Awesome Open Source](https://awesomeopensource.com/) - A platform to find open source projects by searching, browsing, and combining topics across various categories and projects.
+- [Open Source Libs](https://opensourcelibs.com/) - A massive collection of the world's best open source software.
+- [CodeTriage](https://www.codetriage.com/) - A list of open source repositories' issues that you can contribute to, with the option to receive issues via email if you sign up.
+- [GitLab Explore](https://gitlab.com/explore/projects/starred/) - Explore projects on GitLab.
+- [Open Source Guide](https://opensource.guide/) - Guide providing resources for launching and growing open source projects.
+- [The Architecture of Open Source Applications](https://aosabook.org/en/index.html) - Book series about the design and architecture of various open-source software projects.
+- [OSS Gallery](https://oss.gallery/) - A crowdsourced collection of the best open-source projects across the internet, providing an easy way to discover and explore top software repositories and tools.
+
+### Hackathons
+
+- [DEVPOST Hackathons](https://devpost.com/hackathons) - Find online and in-person hackathons.
+- [GitHub Education Events](https://education.github.com/events) - Find members of the community at hackathons, conferences, and events near you.
+- [Hackathons by Hack Club](https://hackathons.hackclub.com/) - Curated list of high school hackathons, featuring 699 events in 27 states and 18 countries.
+- [Cerebral Valley AI Events](https://events.cerebralvalley.ai/) - Provides information on upcoming AI-related events, hackathons, and co-working opportunities.
+
+## Cheat Sheets
+
+- [DevHints](https://devhints.io) - Collection of cheatsheets for various programming languages and tools.
+- [Cheatography](https://cheatography.com/) - Platform providing user-generated cheat sheets on various topics.
+- [Sound of Sorting Algorithm Cheat Sheet](https://panthema.net/2013/sound-of-sorting/SoS-CheatSheet.pdf) - Cheat sheet related to the "Sound of Sorting" algorithm visualization project.
+- [SANS Cheat Sheets](https://www.sans.org/blog/the-ultimate-list-of-sans-cheat-sheets/) - Ultimate list of SANS cheat sheets covering general IT security topics.
+- [Codecademy Cheatsheets](https://www.codecademy.com/resources/cheatsheets/all) - Collection of cheat sheets for various programming languages and concepts.
+- [Awesome Cheatsheets](https://lecoupa.github.io/awesome-cheatsheets/) - Curated list of awesome cheatsheets covering a wide range of programming languages, tools, and topics.
+- [OverAPI](https://overapi.com/) - Platform providing centralized access to cheatsheets and quick references for various programming languages and frameworks.
+- [Nota Language](https://nota-lang.org/) - Document language designed for the browser, offering a simplified syntax for creating web-based documents.
+- [Cheat-Sheets.org](https://www.cheat-sheets.org/) - Compilation of cheat sheets, round-ups, quick reference cards, guides, and sheets covering various topics.
+
+### Python Cheat Sheet
+
+- [Speedsheet](https://speedsheet.io/) - An interactive Python cheatsheet for faster and better coding.
+- [Python Cheatsheet](https://www.pythoncheatsheet.org/) - A cheatsheet based on the book "Automate the Boring Stuff with Python" and various other sources.
+- [Zero to Mastery Python Cheat Sheet](https://zerotomastery.io/cheatsheets/python-cheat-sheet/) - Python cheat sheet provided by Zero to Mastery.
+
+### Front-end Cheat Sheet
+
+- [Can I use](https://caniuse.com/) - Provides up-to-date browser support tables for front-end web technologies on desktop and mobile browsers.
+- [Easings](https://easings.net/en) - Helps you choose the right easing function for animations.
+- [WebCode.tools](https://webcode.tools/) - Code generators to assist with front-end web projects.
+- [MarkSheet](https://marksheet.io/) - Offers a free HTML and CSS tutorial.
+- [Xul.fr](https://www.xul.fr/en/) - A tutorial and index for CSS, HTML, and JavaScript.
+- [Emmet Cheat Sheet](https://docs.emmet.io/cheat-sheet/) - A cheat sheet for Emmet, a toolkit for web developers to write HTML and CSS code faster.
+
+#### HTML Cheat Sheet
+
+- [HTML Cheat Sheet](https://htmlcheatsheet.com) - Comprehensive HTML cheat sheet covering various elements and attributes.
+- [HTML5 Doctor Element Index](https://html5doctor.com/element-index/) - Quick reference for elements that are new or redefined in HTML5.
+- [HTML5 Canvas Cheat Sheet](https://simon.html5.org/dump/html5-canvas-cheat-sheet.html) - Cheat sheet for HTML5 Canvas, providing a quick reference for its properties and methods.
+- [HTML Vocabulary](https://apps.workflower.fi/vocabs/html/en#children) - Resource providing an HTML vocabulary, categorizing elements and their relationships.
+- [HTML Reference](https://htmlreference.io/) - Free guide to HTML, featuring all HTML elements and attributes with detailed explanations.
+
+#### CSS Cheat Sheet
+
+- [CSS Reference](https://cssreference.io) - Comprehensive reference guide for CSS properties and selectors.
+- [Grid Malven](https://grid.malven.co) - Interactive guide for CSS Grid layout.
+- [Flexbox Malven](https://flexbox.malven.co/) - Interactive guide for CSS Flexbox layout.
+- [Justin Aguilar Animations](https://www.justinaguilar.com/animations/) - Collection of CSS animations with live previews.
+- [CSS Grid Cheat Sheet](https://alialaa.github.io/css-grid-cheat-sheet/) - Visual cheat sheet for CSS Grid layout.
+- [Adam Marsden CSS Cheat Sheet](https://adam-marsden.co.uk/css-cheat-sheet) - CSS cheat sheet with concise explanations and examples.
+- [Responsive Web Design Cheat Sheet](https://uxpin.s3.amazonaws.com/responsive_web_design_cheatsheet.pdf) - PDF cheat sheet for responsive web design principles.
+- [Media Queries Cheat Sheet](https://mac-blog.org.ua/css-3-media-queries-cheat-sheet) - Cheat sheet for CSS3 media queries.
+- [Bootsnipp](https://bootsnipp.com/) - Platform providing design elements, playground, and code snippets for Bootstrap HTML/CSS/JS framework.
+- [Bootstrap Cheatsheet](https://hackerthemes.com/bootstrap-cheatsheet/) - Visual cheat sheet for the Bootstrap framework.
+- [HackerThemes](https://hackerthemes.com/) - UI/UX resources based on the Bootstrap framework.
+
+## Building Computer / PC Build
+
+- [PCPartPicker](https://pcpartpicker.com/list/) - Tool for planning and building custom PCs, enabling users to create part lists, compare prices, and ensure compatibility between components.
+- [PCBuilder](https://pcbuilder.net/list/) - Platform for designing custom PC builds, providing component compatibility checks, price comparisons, and configuration options for users.
+- [PC Builds](https://pc-builds.com/) - Resource for custom PC builds, offering curated lists of compatible components, guides, and recommendations for various performance levels and budgets.
+- [LinearMouse](https://linearmouse.app/) - Utility for Mac that provides advanced mouse and trackpad customization options, allowing users to fine-tune gestures, button mappings, and scrolling behavior.
+
+### Keyboard
+
+- [MechanicalKeyboards](https://mechanicalkeyboards.com/index.php) - Largest dedicated catalog of mechanical keyboards worldwide, offering fast shipping and after-sale support.
+- [Keycaps.info](https://www.keycaps.info/) - Resource for keycap enthusiasts, providing information on various keycap profiles, designs, and compatibility for mechanical keyboards.
+- [Keybr](https://www.keybr.com/) - Website offering a platform for improving touch typing skills with customizable lessons.
+- [PairType](https://www.pairtype.com/) - Online tool for practicing touch typing with a partner in real-time.
+- [KeyCombiner](https://keycombiner.com/) - Platform for learning and practicing keyboard shortcuts and key combinations.
+- [Yip-Yip](https://www.yip-yip.com/) - Online tool providing keyboard shortcuts for various applications and programs.
+- [Keebmaker](https://keebmaker.com/) - Resource for creating custom mechanical keyboards.
+- [Colemak - Learn](https://colemak.com/Learn) - Learning resources for the Colemak keyboard layout.
+
+#### Typing Practice
+
+- [TypeFast](https://typefast.io/) - A typing practice platform designed to help users improve their typing speed and accuracy through engaging challenges and exercises.
+- [10FastFingers](https://10fastfingers.com/typing-test/english) - Typing test platform to measure typing speed and accuracy in English.
+- [TypingClub](https://www.typingclub.com/) - Platform providing interactive typing lessons and games to improve typing skills.
+- [Typing.com](https://www.typing.com/) - Online resource offering typing lessons, games, and tests for learners of all levels.
+
+#### Keyboard Shortcuts
+
+- [UseTheKeyboard](https://usethekeyboard.com/) - Collection of keyboard shortcuts for Mac apps, Windows programs, and websites, covering a wide range of common applications.
+- [ASCII Tables](https://ascii-tables.com/) - Online resource providing an ASCII table, ALT codes, Z Score table, Greek Alphabet, T Distribution table, and a Binary Translator.
+- [ShortcutFoo](https://www.shortcutfoo.com/) - Platform for practicing keyboard shortcuts for free, supporting Mac, Windows, Linux, and offering cheat sheets for various applications, languages, and terminals.
+- [Microsoft Word Keyboard Shortcuts](https://support.microsoft.com/en-us/office/keyboard-shortcuts-in-word-95ef89dd-7142-4b50-afb2-f762f663ceb2) - Official Microsoft Office support page providing a comprehensive list of keyboard shortcuts for Microsoft Word.
+
+## Other Websites of Websites
+
+- [Stumbled.to](https://stumbled.to/) - Platform for discovering and sharing interesting websites and content.
+- [5000Best](https://5000best.com/websites/) - Curated collection of the 5000 best websites across various categories.
+- [Neal.fun](https://neal.fun/) - Website featuring entertaining and interactive projects.
+- [Tennessine](https://tennessine.co.uk/) - Collection of political, mathematical, and fun projects for the web.
+- [Blakeir](https://blakeir.com/blog/smart-youtube) - Blog post listing some YouTube pages with smart and insightful content.
+- [AwesomeOSINT on GitHub](https://awesomeopensource.com/project/jivoi/awesome-osint#-pastebins) - GitHub repository containing a curated list of open-source intelligence tools and resources.
+- [MadeWithBubble](https://www.madewithbubble.xyz/) - Platform to discover apps and websites created using the Bubble development platform.
+- [NoviceDock](https://novicedock.com/) - Platform offering curated resources for learning programming and related topics.
+- [Hackr.io](https://hackr.io/) - Platform to find programming courses and tutorials recommended by the programming community.
+- [Limnology](https://limnology.co/en) - Curation of educational YouTube channels in 20 different languages, categorized by topic, with the option to find similar channels.
+- [Tech Blogs](https://tech-blogs.dev/) - List of Awesome Tech Blogs.
+- [Track Awesome List](https://www.trackawesomelist.com/) - Track over 500 awesome list updates, and you can also subscribe to daily or weekly updates via RSS or News Letter.
+- [Internet Is Fun](https://projects.kwon.nyc/internet-is-fun/) - Collection of fun and interesting websites on the internet.
+- [Wiby](https://wiby.me/) - Search engine for the classic web, aiming to recreate the browsing experience of earlier days of the internet, particularly suitable for vintage computers.
+
+<br>
+
+# Contributing
+
+- If you want to add a new category or website:
+  - Do not add a website if it is malicious, dangerous, illegal, etc. (you can check its security by running it through a program such as [VirusTotal](https://www.virustotal.com/gui/home)).
+  - Do not add a website if it is merely for entertainment and not really useful for anything.
+  - To avoiding duplications, seach whether the website is already included.
+  - Create a [pull request](https://github.com/atakanaltok/awesome-useful-websites/pulls).
+
+- If you are a site owner and believe that your site is not described accurately, please [rise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).
+
+- If a website is down for some reason, it is generally kept in the list for archiving purposes, and also in case their maintainers might restore them. However, if the destination of a link has changed or a link is now broken, please [rise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).
+
+<br>
+
+# DISCLAIMER
+
+By accessing and using the Awesome Useful Websites project ("the Project") on GitHub, you agree that the Project is not affiliated with, sponsored by, or endorsed by any of the websites listed. While efforts are made to maintain accurate and up-to-date information, the Project makes no guarantees regarding the accuracy, completeness, or reliability of the content. Changes of the content of linked websites are beyond the Project's control. Users access linked websites at their own risk and discretion. The Project is provided "as is" without any warranties, express or implied.
+
+<br>
+
+# LICENSE
+
+<div align="center">
+
+[<img src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by.png"
+alt="Creative Commons Attribution 4.0 International"
+height="40">](http://creativecommons.org/licenses/by/4.0/)
+
+</div>
+
+This work is licensed under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).
+
+**How to credit:**
+
+- You must add a link to this [GitHub main page](https://github.com/atakanaltok/awesome-useful-websites) in an `about` or `acknowledgments` section visible to the user.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2140 @@
+# Awesome Useful Websites
+
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+
+<br>
+
+Explore the internet's hidden gems with this list of awesome useful websites!
+
+<br>
+
+Most of these websites are gathered from:
+
+- [producthunt.com](https://www.producthunt.com/)
+- [reddit.com/r/InternetIsBeautiful](https://www.reddit.com/r/InternetIsBeautiful/)
+- [news.ycombinator.com](https://news.ycombinator.com/)
+- [x.com/IndieRandWeb](https://x.com/IndieRandWeb)
+
+<br>
+
+Feel free to share this list, star it, and [contribute](#contributing) your own awesome finds.
+
+<br>
+
+## Nomenclature
+
+Certain websites are tagged with the symbols listed below for convenience.
+
+| Symbol | Meaning                                                                                          |
+| :----: | ------------------------------------------------------------------------------------------------ |
+|   $    | Payment Required (There are no free options)                                                     |
+|   @    | Student Friendly (Offers discounts or a free version for students)                               |
+|   !    | Website Down (The website is down for some reason, see the end of [contributing](#contributing)) |
+
+<br>
+
+Each website is included only once. Some websites can fall into multiple categories. If you can't find what you need in a specific category, search for keywords or explore other relevant categories as well. To look up websites, use the [raw](https://raw.githubusercontent.com/atakanaltok/awesome-useful-websites/refs/heads/main/README.md) version.
+
+# Contents
+
+- [Awesome Useful Websites](#awesome-useful-websites)
+  - [Nomenclature](#nomenclature)
+- [Contents](#contents)
+  - [Tools](#tools)
+    - [White Board](#white-board)
+    - [Mind Map / Note Taking](#mind-map--note-taking)
+    - [Diagrams](#diagrams)
+    - [Texts](#texts)
+    - [Automating browser](#automating-browser)
+    - [Comparison](#comparison)
+    - [File](#file)
+    - [Visual](#visual)
+    - [Data Entry](#data-entry)
+  - [DIY](#diy)
+  - [Culture](#culture)
+  - [Language](#language)
+    - [Grammar](#grammar)
+    - [Words \& Meanings](#words--meanings)
+  - [Travel](#travel)
+    - [Globetrotting](#globetrotting)
+    - [Time](#time)
+    - [Flight](#flight)
+    - [Weather](#weather)
+  - [Health](#health)
+    - [Air Quality](#air-quality)
+    - [Food](#food)
+    - [Lawn/Yard care](#lawnyard-care)
+  - [Music / Audio](#music--audio)
+    - [Find Music](#find-music)
+    - [Free Music](#free-music)
+    - [Mix Sounds](#mix-sounds)
+    - [Music Theory](#music-theory)
+      - [Rhyme](#rhyme)
+    - [Spotify](#spotify)
+  - [Movies and Series](#movies-and-series)
+    - [Anime](#anime)
+  - [Media](#media)
+    - [X / Twitter](#x--twitter)
+    - [Reddit](#reddit)
+    - [Discord](#discord)
+  - [Economy](#economy)
+  - [Business](#business)
+    - [Finance](#finance)
+    - [Patents](#patents)
+    - [Marketing](#marketing)
+      - [Social Media](#social-media)
+    - [Trends](#trends)
+    - [Meetings](#meetings)
+  - [Jobs](#jobs)
+    - [Remote Jobs](#remote-jobs)
+    - [Freelancing](#freelancing)
+    - [Portfolio / CV / Resume](#portfolio--cv--resume)
+    - [Careers](#careers)
+  - [Startups](#startups)
+    - [Failures](#failures)
+    - [Finding Ideas](#finding-ideas)
+    - [Connectivity](#connectivity)
+    - [Design](#design)
+      - [Colors](#colors)
+      - [Fonts](#fonts)
+      - [Icons / Icon Packs](#icons--icon-packs)
+      - [Stock Images](#stock-images)
+      - [Wallpapers](#wallpapers)
+  - [Art](#art)
+    - [Photography](#photography)
+    - [Art Communities](#art-communities)
+  - [Academia](#academia)
+    - [Studying](#studying)
+    - [Calculators](#calculators)
+    - [MOOC (Massive Open Online Courses)](#mooc-massive-open-online-courses)
+  - [Science](#science)
+    - [Biographies](#biographies)
+    - [Books, Articles, Texts](#books-articles-texts)
+      - [Book Recommendations and Summaries](#book-recommendations-and-summaries)
+    - [Maps and Data](#maps-and-data)
+      - [Arxiv](#arxiv)
+    - [Infographic](#infographic)
+    - [Philosophy](#philosophy)
+    - [Social Sciences](#social-sciences)
+    - [History](#history)
+    - [Geoscience](#geoscience)
+    - [Biology](#biology)
+  - [Physics](#physics)
+    - [Quantum](#quantum)
+      - [Quantum Games](#quantum-games)
+    - [Astronomy](#astronomy)
+  - [Mathematics](#mathematics)
+    - [Math + Art](#math--art)
+  - [Engineering](#engineering)
+    - [Civil Engineering](#civil-engineering)
+    - [Mechanical Engineering](#mechanical-engineering)
+      - [Materials / Nanotechnology](#materials--nanotechnology)
+    - [Electronics Engineering](#electronics-engineering)
+  - [Computer Science](#computer-science)
+    - [Data Structures and Algorithms (DS\&A)](#data-structures-and-algorithms-dsa)
+    - [Big-O notation](#big-o-notation)
+  - [AI/ML](#aiml)
+    - [Robotics](#robotics)
+    - [LLMs](#llms)
+      - [Prompt Engineering](#prompt-engineering)
+    - [AI tools](#ai-tools)
+    - [Data Science](#data-science)
+    - [Databases](#databases)
+  - [Web Development](#web-development)
+    - [Domain](#domain)
+    - [Front-end](#front-end)
+      - [HTML](#html)
+      - [CSS](#css)
+      - [JavaScript](#javascript)
+    - [Back-End](#back-end)
+      - [APIs](#apis)
+      - [SQL](#sql)
+    - [Web Analytics](#web-analytics)
+      - [Testing](#testing)
+    - [Web 3.0 Dev and Cryptocurrencies](#web-30-dev-and-cryptocurrencies)
+  - [Software Engineering](#software-engineering)
+    - [Android Development](#android-development)
+    - [Game Development](#game-development)
+      - [Game Theory](#game-theory)
+      - [Pokemon](#pokemon)
+      - [Chess](#chess)
+    - [Embeddings](#embeddings)
+    - [Linux](#linux)
+    - [Vim](#vim)
+    - [Git](#git)
+    - [GitHub](#github)
+    - [IDEs](#ides)
+  - [Privacy](#privacy)
+    - [Cryptography](#cryptography)
+    - [GAFA Alternatives](#gafa-alternatives)
+    - [Ad Blocker](#ad-blocker)
+    - [Emails](#emails)
+      - [Disposable Email](#disposable-email)
+    - [Data Breach](#data-breach)
+    - [Search](#search)
+    - [Internet](#internet)
+      - [DNS](#dns)
+    - [URL](#url)
+      - [URL Shortener](#url-shortener)
+    - [VPN](#vpn)
+    - [Fake Information Generation](#fake-information-generation)
+    - [Password Generation](#password-generation)
+  - [Softwares](#softwares)
+    - [Snippets](#snippets)
+    - [Linters](#linters)
+    - [Testing](#testing-1)
+    - [Regex](#regex)
+    - [No-Code](#no-code)
+      - [Licensing](#licensing)
+  - [Programming Languages](#programming-languages)
+    - [Haskell](#haskell)
+    - [Python](#python)
+    - [C++](#c)
+  - [Coding Practice / Competitive Programming](#coding-practice--competitive-programming)
+    - [Capture the Flag](#capture-the-flag)
+    - [Projects](#projects)
+    - [Open Source](#open-source)
+    - [Hackathons](#hackathons)
+  - [Cheat Sheets](#cheat-sheets)
+    - [Python Cheat Sheet](#python-cheat-sheet)
+    - [Front-end Cheat Sheet](#front-end-cheat-sheet)
+      - [HTML Cheat Sheet](#html-cheat-sheet)
+      - [CSS Cheat Sheet](#css-cheat-sheet)
+  - [Building Computer / PC Build](#building-computer--pc-build)
+    - [Keyboard](#keyboard)
+      - [Typing Practice](#typing-practice)
+      - [Keyboard Shortcuts](#keyboard-shortcuts)
+  - [Other Websites of Websites](#other-websites-of-websites)
+- [Contributing](#contributing)
+- [DISCLAIMER](#disclaimer)
+- [LICENSE](#license)
+
+<br>
+
+## Tools
+
+- [5000Best Tools](https://5000best.com/tools/) - 5000 tools.
+- [10015.io](https://10015.io/) - Free all-in-one toolbox for various tasks.
+- [UnTools](https://untools.co/) - Collection of thinking tools and frameworks.
+- [TimeTravel Memento](https://timetravel.mementoweb.org/) - Find Mementos in Internet Archive, Archive-It, British Library, archive.today, GitHub, and more.
+- [discu.eu](https://discu.eu/) - Keep up with the topics you care about through weekly newsletter, social & bots, browser extensions, bookmarklet.
+- [PromoWizard](https://promowizard.softr.app/) - Get promo codes without consuming hours of content on YouTube.
+- [Everybodywiki](https://en.everybodywiki.com/Everybodywiki:Welcome) - Rescues deleted articles and rejected drafts from Wikipedia in multiple languages and welcomes new articles.
+- [Lunar](https://lunar.fyi/) - Multi-featured app for controlling monitors.
+- [GetHuman](https://gethuman.com/) - Get a representative on the phone faster and receive better help from known companies.
+- [S-ings Scratchpad](https://www.s-ings.com/scratchpad/) - Online scratchpad tool designed for quick notes, calculations, and informal writing.
+- [UFreeTools](https://www.ufreetools.com/) - Your Online Free Toolkit.
+- [Play Go Hub](https://playgohub.com/) - Professional Gaming Tools & Guides
+- [rtcd.io](https://rtcd.io/) - Free online toolkit for audio editing, image processing, development and more.
+
+### White Board
+
+- [TypeHere](https://typehere.co/) - Blank website where you can only type.
+- [PixelPaper](https://pixelpaper.io/) - Free-forever digital whiteboard with no registration, can be embedded into SaaS products.
+- [Excalidraw](https://excalidraw.com/) - Whiteboard where you can sketch hand-drawn-like diagrams.
+- [Excalideck](https://excalideck.com/) - App for authoring slide decks that look hand-drawn, based on Excalidraw.
+- [Blank Page](https://blank.page/) - Simple webpage displaying a blank white page.
+- [Kid Pix](https://kidpix.app/) - A bitmap drawing program designed for children, offering a fun, user-friendly interface for creative and interactive digital artwork.
+- [Krita](https://krita.org/en/) - Free, open-source digital painting software designed for artists, offering advanced tools for illustration, concept art, and texture painting.
+
+### Mind Map / Note Taking
+
+- [Relanote](https://relanote.com/) - Interlinking your notes to develop a web of thoughts.
+- [Bubbl.us](https://bubbl.us/) - Mind Mapping Online.
+- [MindMup](https://www.mindmup.com/) - Free online mind mapping.
+- [Anotepad](https://anotepad.com/) - Online notepad. No login. Download your note as PDF or Word document.
+- [Notes.io](https://notes.io/) - Web-based application for taking notes.
+
+### Diagrams
+
+- [Creately](https://creately.com/) - Data-connected Visual Workspace for brainstorming, planning, executing, and capturing knowledge.
+- [draw.io](https://www.drawio.com/) - Open-source, security-first technology stack for building diagramming applications. For [web usage](https://app.diagrams.net/?src=about).
+- [OrgPad](https://orgpad.com/?ref=producthunt) - An interactive online mind map.
+- [Lucidchart](https://www.lucidchart.com/pages/) - A diagramming and flowchart app that brings teams together to make better decisions and build the future.
+- [Learn Anything](https://learn-anything.xyz/) - Platform for organizing the world's knowledge, exploring connections, and curating learning paths.
+- [SankeyDiagram.net](https://sankeydiagram.net/) - Web-based open-source tool for creating & sharing Sankey Diagrams from data
+
+### Texts
+
+- [Word Counter](https://freecodetools.org/word-counter/) - Word counter.
+- [Text Faces](https://textfac.es/) - Write Unicode faces.
+- [Title Case](https://titlecase.com/) - Convert a text into all kinds of cases.
+- [Fancy Text Generator](https://lingojam.com/FancyTextGenerator) - Convert a text into all kinds of fonts.
+- [Calligraphr](https://www.calligraphr.com/en/) - Transform your handwriting or calligraphy into a font.
+- [Dongerlist](https://dongerlist.com/) (!) - Set of Unicode characters assembled to form a text emoticon.
+- [ASCII-art Tutorial](https://stonestoryrpg.com/ascii_tutorial.html) - Tutorial on ASCII art.
+- [Emoji Combos](https://emojicombos.com/) - Collection of emoji combinations and sequences.
+- [ASCII World](https://www.asciiworld.com/) - Platform featuring ASCII art and tutorials.
+- [Rentry](https://rentry.co/FMHY) - Online collaborative markdown editor.
+
+### Automating browser
+
+- [Automa](https://chrome.google.com/webstore/detail/automa/infppggnoaenmfagbfknfkancpbljcca?ref=producthunt) - Chrome extension for automating your browser.
+- [Browse.AI](https://www.browse.ai/) - Platform to extract, set up clicks, and monitor data from any website.
+- [Tango](https://www.tango.us/) - Tool to create step-by-step documentation, how-to playbooks, and product guides with screenshots.
+- [BookmarkOS](https://bookmarkos.com/bookmark-manager-finder) - Allows you to filter through various bookmark managers.
+
+### Comparison
+
+- [Social Media Messaging Apps Comparison](https://docs.google.com/spreadsheets/d/1-UlA4-tslROBDS9IqHalWVztqZo7uxlCeKPQ-8uoFOU/edit#gid=0) - Detailed comparison and analysis of social media messaging apps.
+- [DxOMark](https://www.dxomark.com/category/smartphone-reviews/) - Scientific tests and data on smartphones, sensors, lenses, and speakers.
+- [TechSpecs Compare Phones](https://techspecs.io/vs/) - Compare specifications of phones.
+- [TechSpecs](https://techspecs.io/) - Search engine for consumer electronics products.
+- [Kimovil](https://www.kimovil.com/en/) - Compare specifications and prices of smartphones and tablets.
+- [DiffChecker](https://www.diffchecker.com/) - Compare text, image, PDF, and more to find differences between files.
+- [CodingFont](https://www.codingfont.com/) - Gamified experience to compare and find coding fonts.
+- [This vs That](https://thisvsthat.io/) - Type in two things to compare them to each other.
+- [Secure Messaging Apps Comparison](https://www.securemessagingapps.com/) - A comparison platform for secure messaging apps.
+- [RTINGS](https://www.rtings.com/) - Provides in-depth reviews and comparisons of audio and visual equipment, including TVs, monitors, headphones, and soundbars, with detailed testing and ratings.
+
+### File
+
+- [Wormhole](https://wormhole.app/) - Platform to share files with end-to-end encryption and a link that automatically expires.
+- [Keybase](https://keybase.io/) - End-to-end encrypted secure messaging and file-sharing.
+- [MediaFire](https://www.mediafire.com/) - File storage and sharing platform (with subscription options).
+- [Zippyshare](https://www.zippyshare.com/) - File-sharing service with no sign-up required, no download limits, free, and unlimited disk space.
+
+### Visual
+
+- [Unscreen](https://www.unscreen.com/) - Remove video background automatically and for free.
+- [Remove.bg](https://www.remove.bg/) - Remove image background automatically and for free.
+- [Foco Clipping](https://www.fococlipping.com/) - Remove image background.
+- [Designify](https://www.designify.com/) ($) - Create AI-powered designs by automatically removing backgrounds, enhancing colors, adjusting smart shadows, and more.
+- [PfpMaker](https://pfpmaker.com/) - Make profile pictures from any photo.
+- [JPEG-Optimizer](https://jpeg-optimizer.com/) - Free online tool for resizing and compressing digital photos and images.
+- [Extract.pics](https://extract.pics/) - Extract images from any public website using a virtual browser.
+- [Generated.Photos](https://generated.photos/) - Unique, worry-free (AI-generated), free to download model photos.
+- [Zoom.it](https://zoom.it/) - Create high-resolution, zoomable images.
+- [VectorMagic](https://vectormagic.com/) - Convert bitmaps (JPG, PNG, GIF) to vectors (PDF, SVG, EPS).
+- [Screenshot.Guru](https://screenshot.guru/) - Take high-resolution screen captures of websites and tweets.
+- [Stolen Camera Finder](https://www.stolencamerafinder.com/) - Use the serial number stored in your photos to search the web for other photos taken with the same camera.
+- [Ribbet](https://www.ribbet.com/) - Photo editing tools.
+- [Crossfade.io](https://crossfade.io/) - Web-based video mashups from your favorite sites.
+- [GoProHeroes](https://goproheroes.com/) - GoPro videos across the web.
+- [Synthesia](https://www.synthesia.io/) ($) - AI video creation platform that creates videos from text in minutes.
+- [ClipDrop](https://clipdrop.co/) - Create stunning visuals in seconds, powered by AI.
+- [Reface](https://hey.reface.ai/) - Create face swap videos, a mobile app powered by AI.
+- [PhotoSonic](https://photosonic.writesonic.com/) - AI that paints your dreams with pixels, another version of DALL-E.
+- [Shottr](https://shottr.cc/) - Tiny and fast macOS screenshot tool with annotations, scrolling screenshots, and cloud upload capabilities.
+- [3D GIF Maker](https://www.3dgifmaker.com/) - Create 3D GIFs easily from your images.
+- [EZGIF](https://ezgif.com/) - Online GIF maker and image editor for creating and editing GIFs.
+- [PimEyes](https://pimeyes.com/en) - Facial recognition search engine and reverse image search for finding images containing a specific person.
+- [Visual Illusions](https://sites.socsci.uci.edu/~ddhoff/illusions.html) - Collection of visual illusions and demonstrations.
+- [ByClickDownloader](https://www.byclickdownloader.com/) - Backup videos from various sites in HD, MP3, MP4, AVI, and other formats using their software.
+- [Reanimate](https://reanimate.github.io/) - Build declarative animations with SVG and Haskell.
+- [Photopea](https://photopea.com/) - Free online photo editor similar to Photoshop.
+
+### Data Entry
+
+- [XLSXForm](https://xlsxform.com/) - Build forms and store all data entry in .xlsx file format.
+
+## DIY
+
+- [WikiHow](https://www.wikihow.com/Main-Page) - A collaborative platform for creating and sharing how-to guides.
+- [ManualsLib](https://www.manualslib.com/) - Online repository of user manuals and guides.
+- [This to That](https://thistothat.com/) - Learn how to glue different materials together.
+- [HowStuffWorks](https://www.howstuffworks.com/) - Explore how things work with in-depth explanations and articles.
+- [WonderHowTo](https://www.wonderhowto.com/) - Learn how to do almost anything with instructional videos and step-by-step guides.
+- [Dummies](https://www.dummies.com/) - A series of instructional/reference books.
+- [DoItYourself](https://www.doityourself.com/) - Resources for DIY projects and home improvement.
+- [JScreenFix](https://www.jscreenfix.com/) - Pixel fixing algorithm for repairing defective pixels, particularly effective for stuck pixels. No installation required, and it's free.
+- [Donkey Car](https://www.donkeycar.com/) - Open-source DIY self-driving platform for small-scale cars. It combines an RC car with a Raspberry Pi and is powered by Python (tornado, keras, tensorflow, opencv, etc.).
+- [Instructables](https://www.instructables.com/) - A platform for discovering and sharing DIY projects.
+- [iFixit](https://www.ifixit.com/) - Provides free repair guides and manuals for a wide variety of electronics, appliances, and other products, empowering users to fix items themselves, contributed by the community.
+- [Fix It Club](https://fixitclub.com/) - Save money on home repairs with helpful guides.
+- [BookCrossing](https://bookcrossing.com/) - Release your books "into the wild" for strangers to find or perform a "controlled release" to another BookCrossing member, and track their journey via journal entries from around the world.
+- [Dimensions](https://www.dimensions.com/) - Platform offering visual reference designs for dimensions and measurements across various categories.
+- [Repair Clinic](https://www.repairclinic.com/) - Longest-running source for genuine appliance, HVAC, and outdoor power equipment parts in North America, offering expert advice, how-to resources, and support for DIY repairs. Trusted by professionals and homeowners, the site provides high-quality OEM parts and guidance to help users successfully complete their repairs.
+
+## Culture
+
+- [Cultural Atlas](https://culturalatlas.sbs.com.au/) - Educational resource providing comprehensive information on cultural backgrounds.
+- [QuoteMaster](https://www.quotemaster.org/) - Platform with 98,683 categories and 1,488,431 quotes.
+- [FactSlides](https://www.factslides.com/) - Offers 1001 facts about various topics with sources.
+- [Starkey Comics](https://starkeycomics.com/) - Website featuring colorful images and posts about culture and language.
+- [Unusual Wikipedia Articles](https://en.wikipedia.org/wiki/Wikipedia:Unusual_articles) - Compilation of unusual Wikipedia articles.
+- [List of Common Misconceptions](https://en.wikipedia.org/wiki/List_of_common_misconceptions) - Wikipedia page listing common misconceptions.
+- [Behind the Name](https://www.behindthename.com/) - Provides etymology and history of first names.
+- [Behind the Surname](https://surnames.behindthename.com/) - Offers etymology and history of surnames.
+- [Nameberry](https://nameberry.com/) - Platform for baby names by experts, including popular names, unique names, baby girl names, baby boy names, and gender-neutral names.
+- [Library of Juggling](https://libraryofjuggling.com/) - Online resource of list all of the popular (and perhaps not so popular) juggling tricks in one organized place.
+- [Toaster Central](https://toastercentral.com/) - Collection of working vintage toasters.
+- [All About Berlin](https://allaboutberlin.com/) - Platform offering guides and information for individuals planning to settle in Berlin. Includes details about obtaining visas, finding jobs, securing apartments, and more.
+- [Unita](https://unita.co/) - Platform to discover, compare, and review the best communities, masterminds, and online groups across more than 30+ categories.
+- [Escape Room Tips](https://escaperoomtips.com/) - Tips, tricks, and puzzles for escape rooms
+
+## Language
+
+- [YouGlish](https://youglish.com/) - Use YouTube to improve your English pronunciation.
+- [Voscreen](https://www.voscreen.com/) - Platform providing video snippets of English sentences; test your understanding by choosing paraphrased sentences.
+- [News in Levels](https://www.newsinlevels.com/) - World news tailored for students of English.
+- [Pink Trombone](https://dood.al/pinktrombone/) - Interactive simulation of the human mouth and its sounds using an animated voicebox.
+- [Japanese Wiki Corpus](https://www.japanese-wiki-corpus.org/) - Resource generated from the Japanese-English Bilingual Corpus of Wikipedia's Kyoto Articles.
+- [Latin Phrases](https://latin-phrases.co.uk/) - Reference to look up translations of Latin phrases.
+- [Prismatext](https://prismatext.com/) - Blend the most useful foreign words and phrases into your favorite novels and stories.
+- [Ponly](https://ponly.com/about/) - Website with fun and humorous content and jokes.
+- [Tongue-Twister](https://tongue-twister.net/) - World's largest collection of tongue twisters with 3660 entries in 118 languages
+- [OLAC (Open Language Archives Community)](http://olac.ldc.upenn.edu/) - An international network of institutions and individuals working to create a global virtual library of language resources, focusing on digital archiving practices and providing interoperable repositories for accessing linguistic data.
+- [US Dictionary](https://usdictionary.com/) - Word meanings, synonyms, and usage examples provided for American English terms.
+
+### Grammar
+
+- [GrammarBook](https://www.grammarbook.com/english_rules.asp) - Comprehensive guide to English grammar rules.
+- [The Punctuation Guide](https://www.thepunctuationguide.com/index.html) - Resource offering a guide to American punctuation rules.
+- [Progressive Punctuation](https://progressivepunctuation.com/) - Collection of non-standard punctuation marks.
+- [Purdue OWL](https://owl.purdue.edu/site_map.html) - Purdue University's Online Writing Lab, providing resources on writing, grammar, and citation styles.
+- [Towson University Online Writing Support](https://webapps.towson.edu/ows/index.asp) - Online writing support and grammar resources.
+- [Grammar Monster](https://www.grammar-monster.com/index.html) - Platform offering free English grammar lessons and tests.
+- [Fraze It](https://fraze.it/) - Platform with more than 100 millions sentences.
+
+### Words & Meanings
+
+- [Educalingo](https://educalingo.com/en/dic-en) - Platform to find synonyms, uses, trends, statistics, and more for words.
+- [Fine Dictionary](https://www.finedictionary.com/) - Comprehensive information about a word.
+- [Crown Academy English](https://www.crownacademyenglish.com/articles/) - Provides simple, succinct, and clear explanations of various English language concepts.
+- [Ask Difference](https://www.askdifference.com/) - Offers short and concise differences between two similar subjects.
+- [Key Differences](https://keydifferences.com/) - Website focused on presenting differences and comparisons.
+- [DifferenceBetween.info](https://www.differencebetween.info/) - Provides descriptive analysis and comparisons between different concepts.
+- [Wayne State University's List of Words](https://wordwarriors.wayne.edu/list) - A compilation of words that deserve wider use, curated by Wayne State University.
+- [All Acronyms](https://www.allacronyms.com/) - Community-driven acronyms and abbreviations dictionary.
+- [How to Professionally Say](https://howtoprofessionallysay.akashrajpurohit.com/) - A guide for your daily professional interactions, helping you navigate various situations with a professional tone.
+- [Business English Resources](https://www.businessenglishresources.com/) - A collection of free resources for improving your business English skills.
+- [Digital Glossary](https://www.digital-glossary.com/) - Provides terminological words in Turkish, English, and German for digital contexts.
+- [Bilim Terimleri](https://terimler.org/) - Turkish platform providing explanations and definitions for various terms.
+
+## Travel
+
+- [Airheart - Travel Restrictions](https://airheart.com/travel-restrictions/united-states-vaccinated) - Stay informed about travel restrictions and requirements for your trip, including COVID-19 restrictions.
+- [Country Code](https://countrycode.org/) - A guide to call anywhere in the world, providing country codes for international dialing.
+- [Passport Index](https://www.passportindex.org/) - Explore information about passports from around the world, including rankings and details.
+- [Countries Been](https://www.countriesbeen.com/) - A mobile app to track and list the countries you have visited, offering various features.
+- [Couchsurfing](https://www.couchsurfing.com/) - Connect with a global community of people who share their homes and experiences for free.
+- [Puffin Maps](https://www.puffinmaps.com/) - An all-in-one trip planner with no ads, helping you organize your travel plans.
+- [AllTrails](https://www.alltrails.com/) - Explore a database of 300k trails with reviews and photos from outdoor enthusiasts.
+- [Wanderprep](https://www.wanderprep.com/) - Previously provided advice on gear, apps, and travel tips for smarter journeys.
+- [Looria](https://looria.com/) - A trusted platform to find honest product information.
+- [Trip Destination App (iOS)](https://apps.apple.com/us/app/id1580599572) - A free iPhone app for searching and planning trip destinations.
+- [Freecycle](https://www.freecycle.org/) - A network for people giving and getting items for free in their local communities.
+- [Roadtrippers](https://roadtrippers.com/) - Plan your route and use turn-by-turn navigation to explore various attractions on your road trip.
+- [Mountain Project](https://www.mountainproject.com/) - A free, crowd-sourced guide to climbing destinations around the world.
+- [Welcome to My Garden](https://welcometomygarden.org/) - A non-profit network offering free camping spots in private gardens for slow travelers.
+- [Warmshowers](https://www.warmshowers.org/) - A community of bicycle tourists and hosts supporting them during their journeys.
+- [Slowby](https://www.slowby.travel/) - A platform offering highly-curated slow travel trips for a unique travel experience.
+
+### Globetrotting
+
+- [Random Street View](https://randomstreetview.com/) - Explore streets from around the world without leaving home.
+- [Virtual Vacation](https://virtualvacation.us/) - Take a virtual tour around the globe from the comfort of your home.
+- [MapCrunch](https://www.mapcrunch.com/) - Experience the world through Google Street View by teleporting to random locations.
+
+### Time
+
+- [Every Time Zone](https://everytimezone.com/) - Visual time zone comparison for different countries.
+- [Time and Date](https://www.timeanddate.com/) - Provides calendars, clocks, and various time-related information.
+- [Time.is](https://time.is/) - Displays exact, official atomic clock time for any time zone in 51 languages, covering more than 7 million locations.
+
+### Flight
+
+- [SeatGuru](https://seatguru.com/) - Explore 1,278 aircraft's seat maps to find yours.
+- [Flightradar24](https://www.flightradar24.com/43,24.35/7) - Global flight tracking service providing real-time information about thousands of aircraft around the world.
+- [Skyscanner](https://www.skyscanner.co.in/) - Flight search engine allowing users to search for flights by date, price, and budget.
+
+### Weather
+
+- [Hint.fm Wind Map](https://hint.fm/wind/) - Delicate tracery of wind flowing over the US.
+- [Windy](https://www.windy.com/) - Comprehensive information about the weather for any location.
+- [Zoom Earth](https://zoom.earth/) - Real-time visualization of the world, tracking tropical storms, hurricanes, severe weather, wildfires, and more.
+- [Earth Nullschool](https://earth.nullschool.net/) - Visualization of global weather conditions forecast by supercomputers, updated every three hours.
+- [OpenWeatherMap](https://openweathermap.org/) - Platform providing weather forecasts, newscasts, and historical weather data in a fast and elegant way.
+- [Radiosondy](https://radiosondy.info/) - Tracks meteorological radiosondes, providing a database of current and past radiosonde flights, including information such as launch site, type, last frame, course, speed, altitude, and frequency. (Note: A radiosonde is a battery-powered telemetry instrument usually carried into the atmosphere by a weather balloon.)
+
+## Health
+
+- [MuscleWiki](https://musclewiki.com/) - Platform to learn about your body and muscles.
+- [Just a Minute](https://jinay.dev/just-a-minute/) - Test your chronoception (sense of passing time) in one minute.
+- [FutureMe](https://www.futureme.org/) - Platform to write a letter to your future self.
+- [Strobe.Cool](https://strobe.cool/) - Create visual stimuli using strobe effects.
+- [UnTools](https://untools.co/) - Collection of thinking tools and frameworks to assist in problem-solving, decision-making, and understanding systems.
+- [Puzzle Loop](https://www.puzzle-loop.com/) - Platform offering logic puzzles with simple rules and challenging solutions.
+- [What Should You Do with Your Life?](https://guzey.com/personal/what-should-you-do-with-your-life/) - Article providing directions and advice on life decisions.
+- [InnerBody](https://www.innerbody.com/) - Research for reviews and researches about health products, services, and more.
+- [Sleep Calculator](https://sleepcalculator.com/) - Tool that helps users determine the best time to go to bed based on their desired wake-up time, optimizing sleep cycles for better rest and alertness.
+- [SimpleLab](https://gosimplelab.com/) - Provides rapid, reliable environmental testing across the U.S., using a cloud-based platform for efficient sampling, testing, and data management.
+- [Sleep Estimator](https://www.sleep-estimator.com/) - Calculates the best bedtime based on your wake-up time to optimize sleep quality and alertness.
+- [Sleep Calculator App](https://sleepcalculatorapp.com/) - Find Your Ideal Sleep and Wake Time.
+- [Sleep Cyclecalc App](http://sleepcyclecalcapp.com/) - Find Your Best Sleep Schedule
+- [Sleep Time Calculator](https://www.sleeptimecalculator.org/) - Find Your Perfect Sleep Time
+
+### Air Quality
+
+- [Air Quality Index (European Environment Agency)](http://airindex.eea.europa.eu/) - Provides real-time air quality data across Europe, featuring an interactive map that visualizes air pollution levels and their impact on public health.
+- [Berkeley Earth](http://berkeleyearth.org/) - A non-profit organization focused on providing accurate and comprehensive data on air quality and climate, with tools for visualizing environmental data globally.
+- [World Air Quality Index](https://waqi.info/) - Offers real-time air quality information from around the world, providing an interactive map and detailed data on pollution levels and their effects on health.
+- [IQAir](https://www.iqair.com/) - Operates the world’s largest free real-time air quality monitoring platform, providing critical data to individuals, researchers, and governments to monitor and address air pollution, ultimately helping to protect global public health.
+
+### Food
+
+- [GoBento](https://www.gobento.com/) - Engagement platform focused on improving the health and well-being of at-risk members, particularly those experiencing food insecurity.
+- [MyFridgeFood](https://myfridgefood.com/) - Platform that allows users to check off ingredients they have to find recipes they can make with those ingredients.
+- [Just the Recipe](https://www.justtherecipe.com/) - Platform that provides direct instructions from any recipe site without ads and pop-ups.
+- [Two Peas and Their Pod](https://www.twopeasandtheirpod.com/) - Recipe site offering a variety of recipes.
+- [HelloFresh](https://www.hellofresh.com/) - Meal kit delivery service where users can choose recipes, and HelloFresh delivers the ingredients straight to their door.
+
+### Lawn/Yard care
+
+- [Healthy Yards](https://healthyyards.org) - Resources and tips for eco-friendly and sustainable lawn care practices are offered, with a focus on benefiting local wildlife and the environment.
+- [Homegrown National Park](https://homegrownnationalpark.org) - Information on creating wildlife corridors and contributing to biodiversity by planting native species is provided.
+- [Butterfly Conservation](https://butterfly-conservation.org) - Details on the conservation of butterflies and moths are shared, including species protection and involvement opportunities.
+- [Xerces Society](https://xerces.org) - Guidance on the conservation of pollinators and invertebrates, including habitat restoration and sustainable practices, is available.
+- [Beyond Pesticides](https://beyondpesticides.org) - Resources on organic and sustainable practices for reducing pesticide use and protecting public health and the environment are provided.
+- [National Pesticide Information Center](https://npic.orst.edu) - Science-based information on pesticide use, safety guidelines, and factsheets for consumers and health professionals is offered.
+
+## Music / Audio
+
+- [KHInsider](https://downloads.khinsider.com/) - Video and PC game soundtracks for download in MP3 and lossless formats.
+- [Online Tone Generator](https://onlinetonegenerator.com/) - Generate tones, and you can also download them in WAV format.
+- [Tello Music Charts](https://music.tello.app/) - Find out the latest music charts of all countries in the world.
+- [Music Lab](https://musiclab.chromeexperiments.com/Experiments) - Learning music more accessible through fun, hands-on experiments.
+- [Rap4Ever](https://www.rap4ever.org/) - Explore rap songs, lyrics, mixtapes, albums, artists, and more.
+- [Every Noise](https://everynoise.com/) - Ongoing attempt at an algorithmically-generated scatter-plot of the musical genre-space.
+- [MP3Cut](https://mp3cut.net/) - Trim or cut any audio file online.
+- [MP3Gain](https://mp3gain.flowsoft7.com/) - Increase, decrease, and normalize the volume level of MP3 audio files (60M size limit per file).
+- [Magic Playlist](https://create.magicplaylist.co/#/?_k=m5jobg) - Type your favorite song and create the perfect playlist.
+- [Moises AI](https://moises.ai/) - Play with your favorite artists in any key, at any speed.
+- [Drumeo](https://www.drumeo.com/) - Learn to play the drums with the best teachers in the world.
+- [SoundLove](https://soundlove.se/) - Unusual synthesis algorithms to add a touch of randomness and unpredictability to music.
+- [Audionautix](https://audionautix.com/) - Music composed and produced by Jason Shaw, free for download and use (even for commercial purposes).
+- [Typatone](https://typatone.com/) - Generate your own music by typing on the keyboard.
+- [Incredibox](https://www.incredibox.com/) - Music app that lets you create your own music with the help of a merry crew of beatboxers.
+- [Sampurr](https://www.sampurr.com/) - Sample an audio from the web.
+- [Audiocheck](https://www.audiocheck.net/) - Test your audio equipment online.
+- [Mixlr](https://mixlr.com/) ($) - Share quality live audio online. Broadcast using any source, invite people to listen, and chat in real-time (Free for just listening).
+- [Learn Choral Music](https://www.learnchoralmusic.co.uk/) - John's Musical Instrument Digital Interface (MIDI) file collection of well-known choral works in voice-emphasized form, available for free downloading.
+- [Bandura Festival](https://bandura.ukrzen.in.ua/en#lvivbandurfest) - Online Bandura, a traditional Ukrainian instrument.
+- [AllMusic](https://www.allmusic.com/) - Provides comprehensive and in-depth information on albums, artists, songs, and bands, serving as a valuable resource for music enthusiasts.
+- [ASMR Microphones](https://asmrmicrophones.com) - Reviews, comparisons, and expert opinions on various ASMR microphones are provided to help users select the most suitable equipment.
+
+### Find Music
+
+- [Lalal.ai](https://www.lalal.ai/) - Extract vocal, accompaniment, and various instruments from any audio.
+- [Audd.io](https://audd.io/) - Recognize music or what's playing from sound or streams.
+- [Music-Map](https://www.music-map.com/) - Discover similar music based on your preferences.
+- [Commercial Tunage](https://www.commercialtunage.com/) - Identify songs featured in commercials.
+
+### Free Music
+
+- [Pretzel Rocks](https://www.pretzel.rocks/) - Stream-safe music for Twitch and YouTube.
+- [Incompetech](https://incompetech.com/) - Royalty-free music collection.
+- [Chosic](https://www.chosic.com/) - Free background music for both commercial and non-commercial use.
+
+### Mix Sounds
+
+- [Hidden Life Radio](https://hiddenliferadio.com/) - A livestream of music generated from tree biodata in Cambridge, Massachusetts.
+- [Noisli](https://www.noisli.com/) - Create and listen to background sounds to improve focus and productivity, or to relax and unwind.
+- [Soundrop](https://naim30.github.io/soundrop/) - An interactive music player where you can create beautiful patterns that generate music.
+- [SoundLove](https://www.producthunt.com/posts/soundlove) - A tool that helps you discover and create playlists based on your mood.
+- [Rainy Mood](https://rainymood.com/) - Enjoy the soothing sounds of rain for relaxation, sleep, and study.
+- [I Miss the Office](https://imisstheoffice.eu/) - An office noise generator providing the ambient sounds of modern office life to help recreate the office atmosphere while working from home.
+
+### Music Theory
+
+- [Teoria](https://www.teoria.com/)
+- [MusicTheory.net](https://www.musictheory.net/)
+- [All About Music Theory](https://www.allaboutmusictheory.com/) - Piano keyboard, Music notation, Major scale
+- [Studio Guru - Note Frequency Chart](https://studioguru.co/producer-tools/note-frequency-chart/)
+
+#### Rhyme
+
+- [RhymeZone](https://www.rhymezone.com/) - Find rhymes, synonyms, adjectives, and more.
+- [Rhymer](https://rhymer.com/) - Free online rhyming dictionary.
+
+### Spotify
+
+- [Chosic](https://www.chosic.com/spotify-playlist-analyzer/) - Discover new music by analyzing your playlists.
+- [Pudding](https://pudding.cool/2020/12/judge-my-spotify/) - A.I. trained to evaluate musical taste.
+- [Discoverify Music](https://www.discoverifymusic.com/login) - Discover new music in your taste.
+- [Spottr](https://spottr.vercel.app/login) - View your Spotify stats.
+- [Playlist Mutator](https://playlistmutator.com/) - Mutate existing playlists in React.
+- [TuneMyMusic](https://www.tunemymusic.com/) - Transfer playlists between music services.
+
+## Movies and Series
+
+- [Kanopy](https://www.kanopy.com/en/) (@) - Streaming platform offering thousands of films for free with library or university support.
+- [Movie Map](https://www.movie-map.com/) - Find similar movies based on your preferences.
+- [Reddit Movie Suggestions](https://www.reddit.com/r/MovieSuggestions/wiki/faq) - List of movie suggestions from various genres.
+- [A Good Movie to Watch](https://agoodmovietowatch.com/) - Handpicked, highly-rated movies and TV shows.
+- [Tubi TV](https://tubitv.com/home) - Free streaming service offering a wide range of movies and TV shows.
+- [Tiii.me](https://tiii.me/) - Calculate the total time you've spent watching TV shows.
+- [JustWatch](https://www.justwatch.com/) - Guiding platform for finding and streaming movies and TV shows.
+- [Movie Settings Database](https://www.moviesettingsdatabase.com/) - Organized collection of over 30,000 movies and TV shows by their settings.
+- [Reelgood Netflix Roulette](https://reelgood.com/roulette/netflix) - Randomly suggests a movie or TV show available on Netflix.
+- [Reelgood](https://reelgood.com/) - Browse, search, and watch TV shows and movies from over 150 services, including Netflix, Hulu, HBO, Disney+, Prime Video, and more.
+- [Movie Sounds](https://movie-sounds.org/) - Archive of free movie quotes featuring short sound clips and special effects.
+- [Tunefind](https://www.tunefind.com/) - Discover music from your favorite TV shows and movies.
+- [IMSDB](https://imsdb.com/) - Largest collection of movie scripts available on the web.
+- [Physics in Film and TV](https://physicsinfilmandtv.wordpress.com/) - Blog exploring the portrayal of physics concepts in films and television.
+- [RareFilm](https://rarefilm.net/) - Platform for rare and old films.
+- [I Have No TV](https://ihavenotv.com/) - Watch free online documentaries.
+- [WCostream](https://m.wcostream.com/) - Free cartoon and anime series streaming.
+- [Watch Documentaries](https://watchdocumentaries.com/) - Website offering a collection of documentaries on various topics.
+- [Senses of Cinema](https://www.sensesofcinema.com/) - One of the earliest online film journals, known for its professional, high-quality content related to film studies and industry trends.
+- [Chinese Drama Free](https://www.chinesedramafree.com/) - Chinese Dramas & Short TV Series Online Free to Watch
+
+### Anime
+
+- [Reddit Top Anime Streaming Sites](https://reddit.com/r/streamingAnime/wiki/topsites/) - Wiki page listing top anime streaming sites on Reddit.
+- [Reddit Legal Anime Streams](https://reddit.com/r/anime/wiki/legal_streams/) - Wiki page providing a list of legal anime streaming sites on Reddit.
+
+## Media
+
+- [Radio Garden](https://radio.garden/) - Explore live radio stations represented as green dots on a Google Earth map, allowing you to listen to any of them with just one click.
+- [Radiooooo](https://radiooooo.com/) - "The Musical Time Machine," where you can explore music from different times and places.
+- [Lightyear.fm](https://www.lightyear.fm/) - A representation of how far radio broadcasts have traveled from Earth at the speed of light.
+- [TasteDive](https://tastedive.com/) - Platform to discover music, books, movies, and more based on your preferences.
+- [PIDGI Wiki](https://www.pidgi.net/wiki/Main_Page) - Community-driven video game media database, including artwork, promotional materials, logos, and more.
+- [Kassellabs](https://kassellabs.io/) - Create your own texts on famous intros of movies and series.
+- [USTVGO](https://ustvgo.tv/) - Free live TV channels available online.
+- [All You Can Read](https://www.allyoucanread.com/) - The largest database of magazines and newspapers on the Internet, with listings for about 25,000 publications from all over the world.
+- [LexiCap](https://karpathy.ai/lexicap/) - Transcripts for Lex Fridman's podcast episodes.
+- [Brett Hall's TokCast Transcripts](https://www.aniketvartak.com/html/hall-index.html) - Transcripts for Brett Hall's TokCast podcast.
+- [Thumbly](https://thumbly.ai/) - Turn your script into attention-grabbing thumbnails that can increase your YouTube views.
+
+### X / Twitter
+
+- [TweetDeck](https://tweetdeck.twitter.com/) - Twitter dashboard application for the management of Twitter accounts, tracking, and organizing.
+- [Twitter Video Downloader](https://twittervideodownloader.com) - Online tool to download any Twitter video directly to your mobile or computer.
+- [ThreadReaderApp](https://threadreaderapp.com/) - Platform that helps you save Twitter threads as PDFs, making it easier to read and share them.
+- [Tweepsmap](https://tweepsmap.com/) - AI-driven Twitter analytics and management tool.
+- [Shadowban Checker](https://shadowban.yuzurisa.com/) - Tool to check whether a username is shadowbanned on Twitter.
+- [Twitter Name Generator](https://twitternamegenerator.com/) - Free online tool to generate pretty nicknames for Twitter.
+- [Thread Hunt](https://threadhunt.xyz/) - Platform for discovering quality Twitter threads.
+- [Small World](https://smallworld.kiwi/signin) - Utilizes the location from your Twitter profile to find nearby friends.
+- [Murmel](https://murmel.social/top) - Curates the latest thought-provoking stories from across the Twitterverse.
+- [Chirpty](https://chirpty.com/) - Create your own Twitter interaction circle.
+- [Capture My Tweet](https://capturemytweet.in/) - Turn your tweets into wonderful images for free.
+- [Twitter Card Generator](https://freecodetools.org/twitter-card-generator/) - Tool to generate Twitter cards, attaching rich content to Tweets for free.
+- [Rattibha](https://rattibha.com/) - Curates Twitter threads by categories and authors with time, language, and sorting options.
+- [Musk Messages](https://muskmessages.com/) - Platform compiling and categorizing direct messages from Elon Musk on Twitter, providing easy access to his thoughts and statements.
+
+### Reddit
+
+- [RedditList](https://redditlist.com/) - A comprehensive list of subreddits categorized by various topics.
+- [Redsim](https://anvaka.github.io/redsim/) - Find similar subreddits based on your interests.
+- [Reveddit](https://www.reveddit.com/about/) - Reveals Reddit's removed content. You can search by username, subreddit (r/), link, or domain.
+- [Spacebar Counter - Reddit List](https://www.spacebarcounter.net/reddit-list) - A collection of 100+ subreddits.
+- [Unreadit](https://unreadit.com/) - Reddit-fueled weekly newsletters that curate content from various subreddits.
+- [What Is This Thing](https://whatisthisthing.vercel.app/) - Aggregates posts and answers from the r/whatisthisthing subreddit.
+- [Gummy Search](https://gummysearch.com/) - Explore pain points, content ideas, and discover what people are eager to pay for on Reddit.
+- [RedditSearch.io](https://redditsearch.io/) - An advanced Reddit search engine that allows you to filter and customize your searches.
+- [Better Reddit Search](https://betterredditsearch.web.app/) - Enhance your Reddit search experience with improved features and functionality.
+
+### Discord
+
+- [Blobs](https://blobs.gg/) - Collection of over 4400 fun and playful custom emoji for Discord.
+
+## Economy
+
+- [Investopedia](https://www.investopedia.com/) - A source of financial education, news, and research for investors.
+- [Money](https://money.com/) - A comprehensive resource for personal finance and financial news.
+- [The Balance Money](https://www.thebalancemoney.com/) - Financial education and resources.
+- [CNN Fear and Greed Index](https://edition.cnn.com/markets/fear-and-greed) - Understand the current emotion driving the market.
+- [Where's Willy](https://www.whereswilly.com/) - An international non-profit volunteer project dedicated to tracking Canadian paper money around the world.
+- [Where's George](https://www.wheresgeorge.com/) - A project similar to "Where's Willy" for tracking American paper money globally.
+- [EuroBillTracker](https://en.eurobilltracker.com/) - An international non-profit volunteer project dedicated to tracking Euro notes around the world.
+- [TradingView](https://www.tradingview.com/) - A platform and social network used by over 30 million traders and investors worldwide to spot opportunities across global markets.
+- [LendingTree](https://www.lendingtree.com/) - A marketplace designed to save you money by finding loans rather than making them.
+- [Masterworks](https://www.masterworks.com/) - An exclusive community investing in blue-chip art.
+- [EquityBee](https://equitybee.com/) - Provides startup employees the funding they need to exercise their stock options by connecting them with a global network of investors.
+- [EquityZen](https://equityzen.com/) - Allows you to invest or sell shares in the secondary market with EquityZen funds.
+- [WTF Happened in 1971](https://wtfhappenedin1971.com/) - Website exploring and highlighting various economic, social, and financial events that occurred in the year 1971.
+- [Ergodicity Economics](https://ergodicityeconomics.com/) - Website providing insights into Ergodicity Economics and related concepts.
+
+## Business
+
+- [Crunchbase](https://www.crunchbase.com/) - A platform for discovering innovative companies, startups, and key individuals in the business world. Provides comprehensive data and insights about companies, investments, and industry trends.
+- [Business Model Toolbox](https://bmtoolbox.net/) - A resource to learn about various business concepts and models.
+- [Gumroad](https://gumroad.com/) - E-commerce platform for creators to sell digital products directly to customers.
+- [Humble Bundle](https://www.humblebundle.com/) - Platform selling games, ebooks, software, and digital content with a mission to support charity while providing great content at affordable prices.
+- [Google Takeout](https://takeout.google.com/) - Export a copy of all your Google data.
+- [Honey](https://www.joinhoney.com/) - A browser extension that automatically searches for coupons on over 30,000 sites globally.
+- [BotHelp](https://bothelp.io/widget) - Provides a free chat button widget for websites.
+- [CertificateClaim](https://www.certificateclaim.com/) - A digital service for creating and sending various types of certificates.
+- [Respresso](https://respresso.io/) ($) - A tool to manage your app’s localization texts, images, colors, fonts, and more, delivering them automatically into your projects with a single click.
+- [Bonanza](https://www.bonanza.com/) - An online marketplace that empowers entrepreneurs to build a sustainable business based on repeat customers.
+- [Pipl](https://pipl.com/) - Identify, search, and verify employees using email addresses, social usernames, or phone numbers by searching through Pipl's global index of identity information, reducing customer friction, fighting fraud, and saving time on review and research.
+
+### Finance
+
+- [FIGR](https://www.figr.app/) - Google Docs + Calculator = Personal finances
+- [LiveFortunately](https://app.livefortunately.com/) - Plan for a better financial future. Create a complete financial plan to make the most of your money.
+- [KeeperTax](https://www.keepertax.com/ask-an-ai-accountant-2-0) - AI Accountant for getting help and calculating tax-related questions.
+
+### Patents
+
+- [Espacenet](https://worldwide.espacenet.com/) - Free access to over 130 million patent documents.
+- [Google Patents](https://patents.google.com/) - Search and read the full text of patents from around the world.
+- [WIPO Patentscope](https://patentscope.wipo.int/search/en/search.jsf) - Search 105 million patent documents, including 4.3 million published international patent applications (PCT).
+- [Patently Apple](https://www.patentlyapple.com/patents-applications/) - Explore patent applications made by Apple.
+- [USPTO Report](https://uspto.report/) - Platform providing information and reports related to patents from the United States Patent and Trademark Office.
+
+### Trends
+
+- [Google Trends](https://trends.google.com/trends/?geo=US) - Explore trending topics and insights based on Google searches.
+- [Google Trends - Visualize](https://trends.google.com/trends/hottrends/visualize) - Visualize and explore the hottest trends on Google.
+- [Statista](https://www.statista.com/) - A platform for statistical data and visualizations, providing insights into various industries and topics.
+- [Google Books Ngram Viewer](https://books.google.com/ngrams) - Graphically visualize the occurrence of phrases in a corpus of books over selected years.
+
+### Meetings
+
+- [When2meet](https://www.when2meet.com/) - A free service for scheduling group meetings. It allows users to create and participate in availability surveys to find the best time for a group to meet.
+- [Sessions](https://sessions.us/) - A web-based conferencing tool designed to enhance meetings. It aims to improve the overall meeting experience and is available for free.
+- [Form to Chatbot](https://formtochatbot.com/) - Convert Google forms into interactive conversations in the form of chatbots. This tool helps in creating engaging and dynamic interactions based on form responses.
+
+## Jobs
+
+- [Y Combinator Jobs](https://www.ycombinator.com/jobs) - Discover the best startup jobs curated by Y Combinator.
+- [Coroflot](https://www.coroflot.com/discover) - Job search platform specifically tailored for designers.
+- [Cool Startup Jobs](https://www.coolstartupjobs.com/) - Explore job opportunities in growing startups and give your stock options a chance.
+- [Anon Friendly](https://anonfriendly.com/) - Find jobs that respect your desire for anonymity.
+- [Prompt Engineering Jobs](https://prompt-engineering-jobs.com) - Explore engineering job opportunities with Prompt.
+- [KeyValues](https://www.keyvalues.com/) - Find engineering teams that align with your values.
+- [About.me](https://about.me/) - Platform for freelancers and entrepreneurs to grow their audience and attract clients.
+- [Rejected.us](https://rejected.us/) - Read and share stories of job rejections.
+- [Tech Interview Handbook](https://www.techinterviewhandbook.org/) - Free curated interview preparation materials.
+
+### Remote Jobs
+
+- [Remote OK](https://remoteok.com/) - Job board for remote positions.
+- [Remotive](https://remotive.com/) - Platform connecting remote companies with talented professionals.
+- [Remote.co](https://remote.co/) - Resource for finding remote work opportunities.
+- [Remote Leaf](https://remoteleaf.com/) - Job board focusing on remote opportunities in the tech industry.
+- [Remote Leads](https://remoteleads.io/) - Platform connecting companies with remote leads in the software development field.
+- [RemoteBear](https://remotebear.io/) - Job board for remote positions in tech and design.
+- [RemoteBase](https://remotebase.com/) - Platform connecting remote workers with companies offering remote positions.
+- [JustRemote](https://justremote.co/) - Job board for remote work opportunities.
+- [JS Remotely](https://jsremotely.com/) - Job board specifically for remote JavaScript positions.
+- [Jobspresso](https://jobspresso.co/) - Curated job board for remote work in tech, marketing, and more.
+- [Just Join](https://justjoin.it/) - Job board for remote positions in IT.
+- [FlexJobs](https://flexjobs.com/) - Job board for flexible and remote work opportunities.
+- [We Work Remotely](https://weworkremotely.com/) - Job board for remote positions in various industries.
+- [Daily Remote](https://dailyremote.com/) - Daily updated job board for remote work opportunities.
+- [AngelList Candidates](https://angel.co/candidates/overview) - Platform connecting startups with potential candidates, including remote positions.
+- [Hired](https://hired.com/) - Platform connecting tech talent with innovative companies.
+- [PowerToFly](https://powertofly.com/) - Job board focusing on remote opportunities for women in tech.
+- [SkipTheDrive](https://skipthedrive.com/) - Job board for remote positions in various industries.
+- [Authentic Jobs](https://authenticjobs.com/) - Job board for creative and tech professionals, including remote positions.
+- [Working Nomads](https://workingnomads.co/) - Job board for remote positions in various industries.
+- [Europe Remotely](https://europeremotely.com/) - Job board for remote positions specifically in Europe.
+- [Virtual Vocations](https://virtualvocations.com/) - Job board for telecommute and remote positions.
+- [Benture.IO](https://benture.io) - Job board for remote opportunities in AI training roles.
+
+### Freelancing
+
+- [Remote Starter Kit](https://www.remotestarterkit.com/) - The ultimate list of tools and processes for remote teams.
+- [Fiverr](https://www.fiverr.com/) - Find the perfect freelance services for your business.
+- [Upwork](https://www.upwork.com/) - Hire freelancers and get freelancers jobs online.
+
+### Portfolio / CV / Resume
+
+- [University of Nebraska Omaha - Job & Internship Resources](https://www.unomaha.edu/student-life/achievement/academic-and-career-development-center/career-development/jobs-and-internships/job-internship-resources.php) - Résumé and Cover Letter Resources provided by the Academic and Career Development Center at the University of Nebraska Omaha.
+- [VisualCV](https://www.visualcv.com/resume-samples/) - Collection of 500+ professional resume examples.
+- [SuperPortfolio](https://superportfolio.co/) - Online Portfolio Maker.
+- [Referd.ai](https://www.referd.ai/resume-scanner) - Free resume scanner.
+- [RxResu.me](https://rxresu.me/) - Free and open-source resume builder.
+- [GoodCV](https://www.goodcv.com/) - Create a professional Resume/CV in minutes without Photoshop or AI techniques.
+- [JSON Resume](https://jsonresume.io/) - Upload your JSON resume according to the spec and have it rendered beautifully.
+- [CVmkr](https://cvmkr.com/) - Create, maintain, publish, and share your CVs for free.
+- [Novoresume](https://novoresume.com/) - Online resume builder.
+- [HelloTechRecruiters](https://hellotechrecruiters.com/) - Tailored for tech recruiters.
+- [FlowCV](https://flowcv.com/) - AI-boosted resume builder, cover letter, job tracker, email signature, personal website.
+- [Signature Maker](https://signature-maker.net/) - Create handwritten digital signatures.
+
+### Careers
+
+- [Roadmap.sh](https://roadmap.sh/) - Provides roadmaps for various development areas.
+- [WTF Should I Do With My Life](https://www.wtfshouldidowithmylife.com/) - A resource to explore and learn about different occupations.
+- [path-to-polymath.notion](https://path-to-polymathy.notion.site/path-to-polymathy/Path-To-Polymathy-d7586429b7ce4db1889fc539822b9670) - Arrangement of every discipline and field out there, and what specific topics make them up.
+
+## Startups
+
+- [Startup Growth Calculator](https://growth.tlb.org/) - Calculate how much funding your startup needs for growth.
+- [Startup Equity Calculator](https://capbase.com/startup-equity-calculator/) - Split equity based on different variables for your startup.
+- [Fifty Years Progress Map](https://progress.fiftyyears.com/) - Highlights large markets with low startup investment. Provides a list of massive markets ranked by competitiveness, including market size and total investment in Series A startups over the last 10 years. Calculates a Competition Ratio for each market.
+- [Museum of Websites](https://www.kapwing.com/museum-of-websites) - A gallery showcasing how famous internet companies have changed over time.
+- [Goal Examples](https://hypercontext.com/goal-examples) - A curated list of goal examples for every role in tech.
+- [Startup Resources](https://www.feedough.com/startup-resources/) - A collection of resources categorized for startups.
+- [500+ Free Tools For Startups](https://docs.google.com/spreadsheets/d/1s6-hGBh0_tqa-jd23fsdYuwbmS8UPmElPqaH-Rnoa_A/htmlview) - A comprehensive list of free tools for startups.
+- [Founder Resources](https://www.founderresources.io/) - Free curated resources, templates, and tools for startups.
+- [100+ Resources on GPT-3](https://harishgarg.gumroad.com/l/wiSvc?ref=producthunt) - A curated list of 100+ resources on GPT-3.
+- [100+ Resources for Building a Successful Startup](https://cerdeira.notion.site/b3b5f44d37cf4843b3fcd2f300354467?v=8f3458522f4542d8896ebb3720c14b2d) - A compilation of resources for building a successful startup.
+- [2,500 Accelerators Incubators](https://view.officeapps.live.com/op/view.aspx?src=https%3A%2F%2Fattachments.convertkitcdnn2.com%2F587796%2F16ab0442-1232-4a49-956c-acafd6df4189%2F2%2C500%2520Accelerators%2520Incubators.xlsx&wdOrigin=BROWSELINK) - A list of 2,500 accelerators and incubators.
+- [The Complete Unicorn List](https://view.officeapps.live.com/op/view.aspx?src=https%3A%2F%2Fattachments.convertkitcdnn2.com%2F587796%2F476863f4-bda0-4132-8bd0-d25728513cfd%2FThe%2520Complete%2520Unicorn%2520List.xlsx&wdOrigin=BROWSELINK) - A comprehensive list of 1,016 unicorns (private companies valued +$1B).
+- [GitHub Email Hunter](https://chrome.google.com/webstore/detail/github-email-hunter/ppcegaekdbgcgbapfdcjbhednhmgcjnk) - Find email addresses for GitHub users & repos with one click.
+- [The Angel Philosopher](https://theangelphilosopher.com/) - Compilation of Naval's wisdom, knowledge, and thoughts.
+- [Under Glass](https://underglass.io/) - Analysis of the world's best digital products.
+- [The Perfect Pitch Deck](https://attachments.convertkitcdnn2.com/587796/1e723803-ab50-4a61-9b3a-f347aa436408/The%20Perfect%20Pitch%20Deck.pdf) - Lessons from analyzing 350+ startup pitch decks.
+- [Old Computers Museum](https://oldcomputers.net/) - Explore a museum of old and vintage computers with 150 exhibits.
+- [Startups List](https://www.startups-list.com/) - Collections of the best startups in different places.
+- [Pessimists Archive](https://pessimistsarchive.org/) - Project that jogs our collective memories about the hysteria, technophobia and moral panic that often greets new technologies, ideas and trends.
+
+### Failures
+
+- [Failory - Google Failures](https://www.failory.com/google/) - Learn from Google's +100 failures to build profitable businesses and scale acquired companies.
+- [Killed by Google](https://killedbygoogle.com/) - Projects that Google launched and ended.
+
+### Finding Ideas
+
+- [Random Startup Website Generator](https://tiffzhang.com/startup/) - A random startup website generator.
+- [AnswerSocrates](https://answersocrates.com/) - Discover the questions people are asking on Google about almost any topic, for free.
+- [IdeasAI](https://ideasai.com/) - Ideas that are generated by OpenAI's GPT-3.
+- [AnswerThePublic](https://answerthepublic.com/) - Discover what people are asking about in popular search engines.
+- [List of Emerging Technologies](https://en.wikipedia.org/wiki/List_of_emerging_technologies) - Wikipedia's list of emerging technologies.
+- [UniCorner](https://unicorner.news/) - Newsletter that delivers a 2-minute rundown of an up-and-coming startup to your inbox every Monday morning.
+- [DemandHunt](https://demandhunt.com/) ($) - Platform for discovering and upvoting new startups.
+
+### Connectivity
+
+- [Integromat](https://www.integromat.com/en?pc=referralbonus) - Connect apps and automate workflows in a few clicks.
+- [IFTTT](https://ifttt.com/) - Automate your favorite apps and devices quickly and easily, making them work together in new and powerful ways.
+- [Franz](https://meetfranz.com/) - Manage all your messaging apps like WhatsApp, Facebook Messenger, Slack, Telegram, and more in one platform.
+- [Google Remote Desktop](https://remotedesktop.google.com/) - Remotely connect with your home or work computer, or share your screen with others.
+- [RecWide](https://www.recwide.com/) - Screen and webcam recorder. Free, online (No download required).
+- [1,000 True Fans](https://kk.org/thetechnium/1000-true-fans/) - The concept of cultivating 1,000 true fans for sustainable creative success.
+- [Alias](https://alias.co/) - Stay up to date with the best of the bests.
+- [LittleSis](https://littlesis.org/) - Free database of who-knows-who at the heights of business and government.
+
+### Design
+
+- [Social Image Maker](https://socialimagemaker.io/) - Tool for creating social media images with ease.
+- [Open Source Design Resources](https://opensourcedesign.net/resources/) - Showcase of websites and platforms offering openly licensed icons, fonts, images, tools, and other resources for design purposes.
+- [Transparent Textures](https://transparenttextures.com/) - Platform providing transparent textures for use in design projects.
+- [Collection of $0 Design Tools](https://www.producthunt.com/e/0-design-tools) - A collection of free design tools to aid in project creation.
+- [Easel.ly](https://www.easel.ly/) - Design tool for visualizing various types of information.
+- [Material Design](https://m3.material.io/) - Design system by Google for building high-quality digital experiences for Android, iOS, Flutter, and the web.
+- [Rasterizer.io](https://rasterizer.io/) - Tool for creating dynamic images.
+- [Jitter.Video](https://jitter.video/) ($) - A simple animation tool on the web.
+- [Polotno Studio](https://studio.polotno.com/) - Web application for creating graphical designs without sign-ups and ads, a free alternative to Canva.
+- [BitBof](https://bitbof.com/) - Free painting and sketching apps.
+- [Sumo](https://sumo.app/) - Drawing tool and image editor.
+- [Random Design Stuff](https://randomdesignstuff.com/) - Browse handpicked websites for designers, both useful and unuseful.
+- [Discover NFT Club](https://www.discovernft.club/) - Discover the latest NFT projects.
+- [Haikei](https://app.haikei.app/) - Web-based design tool to generate unique SVG design assets for various purposes.
+- [Spline](https://spline.design/) - Create 3D scenes, edit materials, and model 3D objects, giving control over the outcome of design work.
+- [Visiwig](https://www.visiwig.com/) - Create graphics just by clicking and pasting.
+- [FreeType](https://freetype.org/) - Software library written in C for rendering fonts, capable of producing high-quality output of most vector and bitmap font formats, designed to be small, efficient, highly customizable, and portable.
+
+#### Colors
+
+- [HexColor](https://hexcolor.co/) - Offers various free color tools.
+- [Adobe Color Wheel](https://color.adobe.com/create/color-wheel) - A color wheel that can be used to generate color palettes.
+- [SchemeColor](https://www.schemecolor.com/) - Allows you to download color schemes.
+- [Mobile Palette Generator](https://mobilepalette.colorion.co/) - A tool for generating mobile palettes.
+- [DeGraeve Color Palette Generator](https://www.degraeve.com/color-palette/) - Generates color palettes.
+- [0to255](https://0to255.com/) - A color tool that helps find lighter and darker colors based on any color.
+- [ColorHexa](https://www.colorhexa.com/) - Provides information about any color and generates matching color palettes.
+- [Color Hunt](https://colorhunt.co/) - Discover hand-picked color palettes.
+- [Coolors](https://coolors.co/) - Color scheme generator and palette creation tool, allowing users to explore, create, and share color combinations for design projects.
+- [Colors.lol](https://colors.lol/) - Website offering a simple interface for generating color palettes, with options for saving and exporting them for use in digital design.
+
+#### Fonts
+
+- [Font Squirrel](https://www.fontsquirrel.com/) - Free Font Utopia.
+- [Font Discovery](https://fontdiscovery.typogram.co/) - Weekly design, font, and color creativity newsletter for creators, founders, makers.
+- [MyFonts](https://www.myfonts.com/) - Over 130,000 available fonts, and counting.
+- [Google Fonts](https://fonts.google.com/) - Collection of free and open-source fonts by Google.
+- [DaFont](https://www.dafont.com/) - A popular website offering free fonts for download, with categories for various styles and uses, including decorative, script, and sans-serif fonts.
+- [UCL Fonts Project](http://vecg.cs.ucl.ac.uk/Projects/projects_fonts/projects_fonts.html) - A research project focused on manifold of fonts, providing findings of their work and an interactive 2D Font Manifold Demonstration.
+
+#### Icons / Icon Packs
+
+- [The Noun Project](https://thenounproject.com/) - Platform offering a vast collection of free icons and stock photos, available for use in a wide range of projects and designs.
+- [IconPacks](https://www.iconpacks.net/) - Platform offering a variety of icon packs for personal and commercial use.
+- [Doodlicons on Notion](https://www.notion.so/Doodlicons-519314a92ed3474093a10e44946bbb72) - Doodle icons for project wireframes on Notion.
+- [Illustration Kit](https://illustrationkit.com/) - Collection of free vector illustrations for personal and commercial projects.
+- [FontAwesome](https://fontawesome.com/) - Internet's icon library and toolkit, widely used by designers, developers, and content creators.
+- [Iconshock](https://www.iconshock.com/freeicons/) - Platform offering icons from various open-source collections, with 100k icons available for free download.
+- [3DIcons](https://3dicons.co/) - Collection of 3D icons available for free commercial and personal use under CC0 license.
+- [Fontello](https://fontello.com/) - Icon fonts generator for creating custom icon fonts.
+- [HealthIcons](https://healthicons.org/) - Free and open-source health icons for various use cases.
+- [TablerIcons](https://tablericons.com/) - Open-source free SVG icons, highly customizable, and no attribution required for commercial use.
+- [David Li](https://david.li/) - Platform for particle-based 3D simulations and renderings.
+- [IcoMoon](https://icomoon.io/) - Platform for creating and managing icon fonts.
+- [UTF8Icons](https://www.utf8icons.com/) - Collection of unicode symbols that are part of the utf-8 standard.
+- [Free Isometric Illustrations](https://passionhacks.com/free-isometric-illustrations/) - Collection of free isometric illustrations for various projects.
+- [Illlustrations](https://illlustrations.co/) - Open-source illustrations kit for creative projects.
+- [PixelBazaar](https://www.pixelbazaar.com) - Opinionated icons for brands with character.
+- [Iconfinder](https://www.iconfinder.com/) ($) - Platform offering icons, illustrations, 3D illustrations, designers, and free icons.
+- [Iconz Design](https://iconz.design/) ($) - Premium 3D library of 223 icons.
+- [HugeIcons.pro](https://hugeicons.pro/) ($) - Platform offering over 25,000 icons in 5 unique styles, organized across 57 popular categories.
+
+#### Stock Images
+
+- [The Stocks](https://thestocks.im/) - Aggregator providing access to free stock photos, videos, and music from various sources.
+- [Pexels](https://www.pexels.com/) - Platform offering high-quality stock photos and videos available for free download and use.
+- [Unsplash](https://unsplash.com/) - Website providing a large collection of high-resolution, royalty-free images for creative projects.
+- [FreeImages](https://www.freeimages.com/) - Platform offering a diverse collection of free stock photos for personal or commercial use.
+- [Pixabay](https://pixabay.com/) - Community-driven platform with high-quality stock images, videos, and music shared by contributors.
+- [PNG Guru](https://www.pngguru.in/) - Source for free PNG images, backgrounds, and templates.
+- [Pond5](https://www.pond5.com/free) - Platform offering free stock videos, photos, and music resources.
+- [Critter Pics](https://www.critter.pics/) - Collection of critter pictures for creative projects.
+- [Stock Up](https://stockup.sitebuilderreport.com/) - Indexing 35,356 photos from 31 different free stock photo websites for easy access.
+- [Shutterstock](https://www.shutterstock.com/) - Platform providing a vast library of royalty-free images, videos, vectors, illustrations, and music.
+- [Zoom.nl](https://zoom.nl/) - Largest photography community in the Netherlands, offering resources and a platform for photography enthusiasts.
+- [Depositphotos](https://depositphotos.com/) - Platform with 232 million files, including royalty-free images, videos, vectors, illustrations, and music.
+- [Skuawk](https://skuawk.com/) - Source of public domain photos for various creative projects.
+- [All-Free-Download](https://all-free-download.com/) - Platform offering graphics art available for free use in personal or commercial projects.
+
+#### Wallpapers
+
+- [Wallpapers.com](https://wallpapers.com/) - Website providing a variety of wallpapers for different themes and styles.
+- [WallpaperCave](https://wallpapercave.com/) - Platform offering a collection of high-quality wallpapers across various categories.
+- [Wallhaven](https://wallhaven.cc/) - Wallpaper community with a vast collection of high-resolution wallpapers.
+- [MovieMania](https://www.moviemania.io/phone) - Database of textless high-resolution movie wallpapers for phones.
+- [WallpaperTip](https://www.wallpapertip.com/) - Platform for uploading and discovering free HD wallpapers.
+- [SimpleDesktops](https://simpledesktops.com/browse/) - Collection of minimal wallpapers for desktop backgrounds.
+- [WallpaperFlare](https://www.wallpaperflare.com/search?wallpaper=vertical) - Website offering high-resolution vertical wallpapers.
+- [Positron Dream](https://www.positrondream.com/wallpapers-all) - Collection of abstract wallpapers available for download.
+- [KPopDemonHuntersWallpaper](https://kpopdemonhunterswallpaper.com/) - KPop Demon Hunters Wallpaper - Free HD Wallpapers Download.
+
+## Art
+
+- [WeavesSilk](https://weavesilk.com/) - Create beautiful flowing art with Silk.
+- [Google Arts & Culture](https://artsandculture.google.com/) - A platform bringing the world’s art and culture online for everyone.
+- [ArtGraphica](https://www.artgraphica.net/) - A resource for free drawing, sketching, and painting techniques.
+- [Tattoos Wizard](https://tattooswizard.com/) - Find tattoo artists and studios near you.
+- [The Art Institute of Chicago Collection](https://www.artic.edu/collection) - Explore thousands of artworks in the museum’s collection.
+- [ZoomQuilt](https://zoomquilt.org/) - Collaborative infinitely zooming painting.
+- [Invaluable](https://www.invaluable.com/) - The world's premier online auctions platform, featuring thousands of items added daily. Invaluable provides accessibility to discovering and acquiring exceptional art and objects anytime, anywhere.
+- [50 Watts](https://50watts.com/) - Archive of weird and wonderful visual ephemera from around the world
+
+### Photography
+
+- [Cambridge in Colour](https://www.cambridgeincolour.com/) - Learning community for photographers
+- [Exposure Guide](https://www.exposureguide.com/) - Photography Tips, Techniques, and Tutorials
+
+### Art Communities
+
+- [Ello](https://ello.co/discover)
+- [Behance](https://www.behance.net/)
+- [ArtStation](https://www.artstation.com/)
+
+## Academia
+
+- [TLDR This](https://tldrthis.com/) - Platform to summarize any piece of text into concise, easy-to-digest content, helping users overcome information overload.
+- [Archive.org General Index](https://archive.org/details/GeneralIndex) - General index providing access to over 107 million journal articles.
+- [Homework Help Global](https://www.homeworkhelpglobal.com/) - Online platform offering professional and custom essay writing services.
+- [Dartmouth Academic Careers](https://sites.dartmouth.edu/nyhan/academic-careers/) - Resource providing insights into academic careers.
+- [CNX](https://cnx.org/) - Platform to view and share free educational materials.
+- [Reach Out Michigan Tutorials](https://www.reachoutmichigan.org/learn/tutorials.html#math) - Collection of online tutorials and references covering various topics.
+- [Open Text BC](https://opentextbc.ca/) - Simple book production software allowing users to publish textbooks, scholarly monographs, syllabi, fiction and non-fiction books, white papers, and more in multiple formats.
+- [Modern for Wikipedia](https://chrome.google.com/webstore/detail/modern-for-wikipedia/emdkdnnopdnajipoapepbeeiemahbjcn) - Chrome extension enhancing the Wikipedia experience with a modern and customizable design.
+- [Wikiwand - Wikipedia Modern](https://chrome.google.com/webstore/detail/wikiwand-wikipedia-modern/emffkefkbkpkgpdeeooapgaicgmcbolj) - Chrome extension optimizing Wikipedia's content for an improved reading experience.
+- [List of Academic Databases and Search Engines](https://en.wikipedia.org/wiki/List_of_academic_databases_and_search_engines) - Wikipedia page listing academic databases and search engines.
+- [Scribbr APA Citation Generator](https://www.scribbr.com/citation/generator/apa/) - Platform providing accurate APA citations, verified by experts and trusted by millions.
+- [Bridges: About Institutions, Histories, and Artifacts](https://temple.manifoldapp.org/projects/bridges) - Resource about institutions, histories, and artifacts of United States college and university life.
+- [Tropy](https://tropy.org/) - Platform to organize research by turning photos into items.
+- [Linda Hall Library Catalog](https://catalog.lindahall.org/discovery/search?vid=01LINDAHALL_INST:LHL) - Catalog of the Linda Hall Library that allows you to search for books, journals, conference proceedings, technical reports and standards, and other materials, focusing on science, engineering, and technology.
+- [Project Abstracts](https://projectabstracts.com/) - Collection of project abstracts and downloads for academic mini projects and final year projects across various fields.
+- [SCIRP Open Access Journal](https://www.scirp.org/journal/OpenAccess) - Platform offering open-access academic journals across various scientific disciplines, promoting free access to research.
+- [DOI.org](https://www.doi.org/) - The official website for Digital Object Identifiers (DOI), providing a system for the persistent identification and access of digital resources, including academic papers and datasets.
+
+### Studying
+
+- [Bartleby](https://www.bartleby.com/) - A platform to search for textbooks, step-by-step explanations to homework questions, and more.
+- [Chegg](https://www.chegg.com/) ($) - A service offering 24/7 course help, including textbook solutions and expert Q&A.
+- [Chegg Flashcards](https://www.chegg.com/flashcards) (@) - Study with flashcards created by students and experts for various courses.
+
+### Calculators
+
+- [Calc Resource](https://calcresource.com/index.html) - Platform offering a variety of calculators and resources for mathematical calculations.
+- [eFunda](https://www.efunda.com/home.cfm) - Website providing calculators, formulas, and information on materials and processes.
+- [LCM Calculator](https://www.calculator.net/lcm-calculator.html) - Calculator for finding the Least Common Multiple.
+- [GCF Calculator](https://www.calculator.net/gcf-calculator.html?numberinputs=9%2C+57%2C+72&x=75&y=22) - Calculator for finding the Greatest Common Factor.
+- [CalculatorSoup](https://www.calculatorsoup.com/) - Online platform offering a variety of calculators for different mathematical purposes.
+- [RapidTables](https://www.rapidtables.com/) - Website providing a collection of calculators and tables for quick reference.
+- [Linear Algebra Calculator](https://www.emathhelp.net/en/linear-algebra-calculator/?u=3%2C1%2C4&v=-2%2C0%2C5&action=cross+product) - Calculator for linear algebra calculations, such as cross product.
+- [Wikipedia: List of Physical Quantities](https://en.wikipedia.org/wiki/List_of_physical_quantities) - Wikipedia page listing various physical quantities.
+- [eMathHelp Linear Algebra Calculator](https://www.emathhelp.net/en/calculators/linear-algebra/) - Online calculator for linear algebra calculations.
+- [Online Math School](https://onlinemschool.com/math/assistance/) - Platform providing math assistance with various calculators and resources.
+- [Percentage Calculator](https://www.percentofpercentcalculator.com) - A simple, interactive tool for calculating percentages quickly and accurately.
+
+### MOOC (Massive Open Online Courses)
+
+- [InfoCobuild - Audio Video Courses](http://www.infocobuild.com/education/audio-video-courses/) - Collection of free audio/video lectures for academic courses from colleges and universities around the world. It is well-categorized with academic subjects including biology, chemistry, computer science, economics, electronics and electrical engineering, history, literature, materials science, mathematics, physics, and psychology.
+- [MIT OpenCourseWare](https://ocw.mit.edu/) - MIT's initiative offering free and open access to a wide range of course materials.
+- [Coursera](https://www.coursera.org/) - Online learning platform providing courses, certificates, and degree programs from universities and organizations worldwide.
+- [Wikiversity](https://en.wikiversity.org/wiki/Wikiversity:Main_Page) - Wikimedia Foundation project providing free educational content and resources.
+- [Udemy](https://www.udemy.com/) - Platform offering a vast array of online courses on various subjects, taught by experts.
+- [Open Culture](https://www.openculture.com/) - Website providing free cultural and educational media, including courses, textbooks, and audiobooks.
+- [edX](https://www.edx.org/) - Online learning platform offering courses, certificates, and degrees from universities and institutions around the world.
+- [Udacity](https://www.udacity.com/) - Platform specializing in tech-related courses and nanodegree programs designed in collaboration with industry leaders.
+- [Stanford Online](https://online.stanford.edu/) - Stanford University's platform for online learning, offering a variety of courses and programs.
+- [OpenLearn](https://www.open.edu/openlearn/) - The Open University's initiative providing free access to course materials and educational resources.
+- [Open Learning Initiative (OLI)](https://oli.cmu.edu/) - Carnegie Mellon University's platform offering openly available courses and resources.
+- [MITx](https://www.mitx.org/) - MIT's platform providing online courses and programs with a focus on cutting-edge research.
+- [Open Yale Courses](https://oyc.yale.edu/) - Yale University's initiative providing free access to introductory courses taught by distinguished faculty.
+- [Alison](https://alison.com/) - Platform offering free online courses and diplomas across a range of subjects.
+- [Academic Earth](https://academicearth.org/) - Website aggregating online courses from top universities worldwide.
+- [NPTEL](https://nptel.ac.in/) - National Programme on Technology Enhanced Learning, providing online courses in engineering and science.
+- [University of the People](https://www.uopeople.edu/) - Online university offering tuition-free, accredited degree programs.
+- [Canvas Network](https://www.canvas.net/) - Platform offering online courses and programs from various institutions using the Canvas learning management system.
+- [Isaac Newton Institute for Mathematical Sciences](https://www.newton.ac.uk/) - Institute's website providing access to mathematical science resources and programs.
+- [Saylor Academy](https://www.saylor.org/) - Nonprofit initiative offering free, self-paced online courses.
+- [Connexions](https://cnx.org/) - Platform providing open educational resources and textbooks in various subject areas.
+- [Directory of Open Access Journals (DOAJ)](https://doaj.org/) - Online directory providing access to high-quality, open-access scientific and scholarly journals.
+- [Learning on the Internet](https://www.learningontheinternet.com/?ref=producthunt) - Platform featuring curated educational content and resources from various sources.
+- [Class Central](https://www.classcentral.com/) - Search engine and reviews platform for online courses, aggregating courses from various providers.
+- [OCW SNU](https://ocw.snu.ac.kr/) - Open CourseWare from Seoul National University.
+
+## Science
+
+- [Reproducibility Institute](https://reproducibilityinstitute.org/w/) - Projects that provide academic papers, cheatsheets, and torrents for paid courses.
+- [EBSCO](https://www.ebsco.com/) - Provider of research databases, e-journals, magazine subscriptions, ebooks, and discovery service.
+- [Zooniverse](https://www.zooniverse.org/) - Participate in real research with over 50 active online citizen science projects.
+- [Experiment](https://experiment.com/) - Help fund the next wave of scientific research.
+- [Closer to Truth](https://www.closertotruth.com/) - Robert Lawrence Kuhn explores the fundamental questions of the universe.
+- [Nature Scitable](https://www.nature.com/scitable/) - Library of scientific overviews. Customize your own eBooks, create an online classroom, contribute and share content, and connect with networks of colleagues.
+- [Vinaire](https://vinaire.me/) - Physics and Math classes.
+- [VisualPDE](https://visualpde.com/) - Interactive platform for exploring science and mathematics, offering simulations on topics like waves, viruses, and reaction-diffusion patterns.
+- [Whole Earth](https://wholeearth.info/) - Nearly-complete archive of Whole Earth publications, a series of journals and magazines published by Stewart Brand and the POINT Foundation from 1968 to 2002, made available for scholarship, education, and research purposes.
+- [Sketchplanations](https://sketchplanations.com/categories/science) - Collection of simple sketches and visual explanations on scientific concepts, aimed at making complex topics more accessible.
+
+### Biographies
+
+- [Mathematics History](https://mathshistory.st-andrews.ac.uk/) - Free online resource containing biographies of more than 3000 mathematicians and over 2000 pages of essays and supporting materials.
+- [Web of Stories](https://www.webofstories.com/) - Listen to life stories of some of the greatest people of our time.
+- [Letters of Note](https://lettersofnote.com/) - History’s most fascinating letters.
+- [Organism Earth Library](https://www.organism.earth/library/).
+- [Darwin Project](https://www.darwinproject.ac.uk/) - Letters written by the evolutionary scientist, Charles Darwin (1809–1882).
+- [Darwin Online](https://darwin-online.org.uk/) - The world's largest and most widely used resource on Charles Darwin.
+- [Newton Project](https://www.newtonproject.ox.ac.uk/) - Online edition of all of Sir Isaac Newton’s (1642–1727) writings.
+- [Bethe](https://bethe.cornell.edu/index.html) - Personal and historical perspectives of Hans Bethe.
+- [Open Source Shakespeare](https://www.opensourceshakespeare.org/) - Open source Shakespeare.
+- [Leonardo da Vinci](https://www.leonardodavinci.net/) - Leonardo da Vinci, his life, and artworks.
+- [Our Karl Popper](https://ourkarlpopper.net/) - How Karl Popper has made a difference in our lives (Testimonies from the five continents).
+- [Varlam Shalamov](https://shalamov.ru/en/) - Writings and historical background of Varlam Shalamov, a Russian writer known for his series of short stories about imprisonment in Soviet labor camps.
+- [Samuel Beckett On-Line Resources](https://www.samuel-beckett.net/) - The Samuel Beckett On-Line Resources and Links Pages. (Samuel Beckett's [Waiting for Godot](https://www.samuel-beckett.net/Waiting_for_Godot_Part1.html))
+- [Philip K. Dick](https://philipdick.com/) - Devoted to the life and work of Science Fiction writer Philip K. Dick (1928-82).
+- [Alan Turing Digital Archive](https://turingarchive.kings.cam.ac.uk/) - This digital archive contains many of Turing's letters, transcriptions of talks, photographs, and unpublished papers.
+- [Turing.org.uk](https://www.turing.org.uk/) - Platform dedicated to the life and work of Alan Turing, the mathematician and computer scientist.
+- [Sherlock Holmes Series](https://sherlock-holm.es/) - Sir Arthur Conan Doyle's Sherlock Holmes series (Public Domain, Copyright-free).
+- [Feynman Lectures Online](https://www.feynmanlectures.caltech.edu/) - Richard Feynman's lectures online.
+- [Leibniz Translations](https://www.leibniz-translations.com/index2.php) - Resource offering translations of the works of philosopher and mathematician Gottfried Wilhelm Leibniz.
+- [David Hume](https://davidhume.org/) - Platform dedicated to the Scottish philosopher David Hume. Accurate, helpful presentation of virtually everything Hume ever wrote.
+- [Fooled by Randomness](https://fooledbyrandomness.com/) - Nassim Nicholas Taleb's Home Page.
+- [Prabook](https://prabook.com/web/home.html) - Platform providing biographical information on notable individuals.
+- [Famous Mathematicians](https://famous-mathematicians.org/) - Website featuring information and biographies of famous mathematicians.
+
+### Books, Articles, Texts
+
+- [Archive.org/texts](https://archive.org/details/texts) - A digital library offering free universal access to a vast collection of digital content.
+- [Open Library](https://openlibrary.org/) - A universal catalog for book metadata with access to a wide range of digital books.
+- [OpenStax](https://openstax.org/) - Provides free and flexible textbooks and resources for educational purposes.
+- [Project Gutenberg](https://www.gutenberg.org/) - A digital library offering over 60,000 free eBooks, including many classics.
+- [Wikibooks](https://en.wikibooks.org/wiki/Main_Page) - An open-content collection of textbooks that anyone can edit.
+- [Wikisource](https://wikisource.org/wiki/Main_Page) - A free library that allows collaborative improvement of its content.
+- [MIT Classics](https://classics.mit.edu/) - Select from a list of 441 works of classical literature by 59 different authors.
+- [Goodreads Free eBooks](https://www.goodreads.com/ebooks?sort=readable) - Free books available on Goodreads.
+- [Lit2Go](https://etc.usf.edu/lit2go/) - A free online collection of stories and poems in audiobook format (Mp3).
+- [Booksc](https://booksc.org/) - World's largest scientific articles store with 70,000,000+ free articles.
+- [IntechOpen](https://www.intechopen.com/books) - Read, share, and download more than 5,800 peer-reviewed Open Access books.
+- [FreeTechBooks](https://www.freetechbooks.com/) - A database of free/open access online computer science books, textbooks, and lecture notes.
+- [FreeComputerBooks](https://freecomputerbooks.com/) - Platform offering a collection of free computer science and programming books.
+- [Manning](https://www.manning.com/) - A publisher of programming books.
+- [Holy Books](https://holybooks.com/) - Download spiritual texts as free PDF e-books.
+- [Librivox](https://librivox.org/) - Provides free public domain audiobooks read by volunteers from around the world.
+- [Online Books Page](https://onlinebooks.library.upenn.edu/) - A listing of over 3 million free books on the web.
+- [Audible](https://www.audible.com/) - A platform offering premium audio storytelling with a wide selection of audiobooks.
+- [VCU Transcendentalism](https://archive.vcu.edu/english/engweb/transcendentalism/) - An educational hypertext space on transcendental texts with links to other internet spaces.
+- [Library of Short Stories](https://www.libraryofshortstories.com/) - An online library with over 1000 classic short stories available for reading and download.
+- [SlideShare](https://www.slideshare.net/) - Online platform for sharing presentations and documents.
+- [Free-eBooks.net](https://www.free-ebooks.net/) - Discover 1000's of New Authors in Hundreds of Categories Fiction and Non-Fiction.
+- [University of Pennsylvania Digital Library](https://digital.library.upenn.edu/books/) - Digital library providing access to a collection of books.
+- [Feedbooks Public Domain](https://www.feedbooks.com/catalog/public_domain) - Platform offering a catalog of public domain books for free.
+- [Authorama](https://www.authorama.com/) - Platform providing a collection of public domain books by different authors.
+- [Google Play - Top Selling Free Books](https://play.google.com/store/books/collection/topselling_free?clp=ChcKFQoPdG9wc2VsbGluZ19mcmVlEAcYAQ%3D%3D:S:ANO1ljKuey8&gsr=ChkKFwoVCg90b3BzZWxsaW5nX2ZyZWUQBxgB:S:ANO1ljIbX7M) - Collection of top-selling free books on Google Play.
+- [Taoism.net](https://taoism.net/) - Resource for exploring Taoism.
+- [Early Modern Texts](https://earlymoderntexts.com/) - Platform providing modern English translations of early modern philosophical texts.
+- [Online Library of Liberty](https://oll.libertyfund.org/) - Curated collection of scholarly works that engage with vital questions of liberty.
+- [Online Books Library](https://onlinebooks.library.upenn.edu/) - University of Pennsylvania's online library providing access to 3 million free books on the Web.
+- [Elegant eBooks](https://www.ibiblio.org/ebooks/) - Find great classics of fiction and non-fiction in stylish editions. Almost all of the ebooks on this site were made from books that are in the public domain.
+- [22 Free Data Science Books](https://www.wzchen.com/data-science-books) - A compilation of quality data science books available for free, curated to assist those exploring the data science career track. The last updated date of each book is included in parentheses.
+- [Chest of Books](https://chestofbooks.com/) - Free online library offering a large collection of books on various topics, including science, technology, art, and literature.
+- [Stephen Wolfram: A New Kind of Science](https://www.wolframscience.com/nks/) - Online version of Stephen Wolfram's book "A New Kind of Science," offering access to the table of contents and related materials on cellular automata and complexity.
+- [Werewolf Reads](https://www.werewolfreads.com/) - A website that shares only werewolf related novels and stories
+
+#### Book Recommendations and Summaries
+
+- [Read Next](https://read-next.com/) (!) - A collection of 3,000+ books recommended by famous people from various domains such as scientists, investors, entrepreneurs, celebrities, and authors.
+- [Goodbooks](https://www.goodbooks.io/) - Offers 8,500+ book recommendations from successful and interesting individuals around the world.
+- [Most Recommended Books](https://mostrecommendedbooks.com/) - Curates 500+ experts, 600+ lists, 500+ book series, providing 100% verified book recommendations.
+- [Books Chatter](https://bookschatter.com/) - Find book recommendations from people's tweets, with tweets shown.
+- [Leafmarks](https://www.leafmarks.com/) - Explore book recommendations from famous authors, top CEOs, legendary investors, and favorite celebrities.
+- [Bookstash](https://bookstash.io/) - Features top books recommended by famous individuals, summarized in 3 minutes or less.
+- [Abakcus](https://abakcus.com/books/) - A collection of books about mathematics and some science.
+- [BookBub](https://www.bookbub.com/welcome) - Get personalized book recommendations based on your preferences.
+- [Hacker News Books](https://hackernewsbooks.com/) - Curates the best books mentioned on Hacker News each week.
+- [Goodreads](https://www.goodreads.com/) - The world's largest site for readers and book recommendations.
+- [What Should I Read Next?](https://www.whatshouldireadnext.com/) - Enter a book you like and the site will analyse our huge database of real readers' favorite books to provide book recommendations and suggestions for what to read next.
+- [Blas](https://blas.com/) - Summarizes more than 400 books by Blas Moros.
+- [Google Books - Talk to Books](https://books.google.com/talktobooks/) - Platform allowing users to have a conversation with books using natural language.
+- [Booktorium](https://booktorium.com/) - A highly user-friendly and constantly updated platform that provides comprehensive and well-organized book series orders, along with continuously improving features.
+
+
+### Maps and Data
+
+- [Our World in Data](https://ourworldindata.org/covid-vaccinations) - COVID-19 vaccination data by country.
+- [WebSDR](https://websdr.org/) - A Software-Defined Radio receiver connected to the internet, allowing many listeners to listen and tune it simultaneously, capturing current signals from Earth.
+- [GSM Security Map](https://gsmmap.org/) - A map comparing the protection capabilities of mobile networks regarding GSM security.
+- [International Campuses](https://cbert.org/resources-data/intl-campus/) - A list of international campuses.
+- [United States International College Campuses on Google Maps](https://www.google.com/maps/d/u/0/viewer?mid=1ckm_TSM8mbCrnhA8COpBNG-qJqTR2IW3&ll=43.664774893391936%2C24.56718262638249&z=5) - Map showcasing international college campuses in the United States.
+- [Submarine Cable Map](https://www.submarinecablemap.com/) - Interactive map showcasing the world's submarine cable systems.
+- [Observable](https://observablehq.com/) - A platform to explore, analyze, and explain data collaboratively.
+- [FixPhrase](https://fixphrase.com/) - Locate any place on Earth with just four words, useful for situations where dealing with a few words is more convenient than a long series of numbers.
+- [Common Crawl](https://commoncrawl.org/) - An open repository of web crawl data that can be accessed and analyzed by anyone.
+- [Mount Everest 3D Map](https://mount-everest3d.com/3d-map/) - Interactive 3D map of Mount Everest.
+- [Visualize Value Archive](https://archivve.visualizevalue.com/) - Archive of visual content from Visualize Value.
+- [Fliist](https://fliist.com/en) - Platform for creating and sharing your favorite lists.
+- [Search Engine Map](https://www.searchenginemap.com/) - Visual representation of popular search engines.
+- [Friendly Dubinsky](https://friendly-dubinsky-cb22fe.netlify.app/) - Maps of different places.
+- [Real-Time SpaceX Starlink Satellite Tracker](https://www.starlinkmap.org/) - Website providing a real-time tracker for SpaceX Starlink satellites.
+- [Album of Computational Fluid Motion](https://album-of-cfm.com/) - Collection showcasing computational fluid motion images.
+- [Visualization of Every Job Title in the World](https://duarteocarmo.com/blog/every-job-world) - Interactive visualization categorizing every single job title in the world into 10 categories.
+- [ObservableHQ](https://observablehq.com/@tophtucker/examples-of-bitemporal-charts) - Examples of bitemporal charts
+- [The Uncensored Library](https://uncensoredlibrary.com/en) - Minecraft server and map released by Reporters Without Borders and created by BlockWorks, DDB Berlin, and MediaMonks as an attempt to circumvent censorship in countries without freedom of the press
+- [Lighthouse Map](https://geodienst.github.io/lighthousemap/) - An interactive map displaying the locations of lighthouses around the world, offering geospatial information and history for each site.
+- [Wikipedia Landscape - Leland McInnes](https://lmcinnes.github.io/datamapplot_examples/wikipedia/) - Visualization showcasing the landscape of Wikipedia.
+- [AAA Gas Prices](https://gasprices.aaa.com/) - Average fuel prices updated daily from up to 120,000 U.S. stations, compiled by OPIS and WEX.
+- [ASCE Hazard Tool](https://ascehazardtool.org/) - Design parameters for structures retrieved based on ASCE standards, including seismic, wind, and flood data.
+
+#### Arxiv
+
+- [ArxivXplorer](https://arxivxplorer.com/) - Search tool designed for exploring scientific papers on arXiv, allowing users to find and filter research articles across various disciplines.
+- [Interactive Data Map of ArXiv Machine Learning Papers](https://datamapplot.readthedocs.io/en/latest/auto_examples/plot_interactive_arxiv_ml.html) - Interactive data map displaying papers from the Machine Learning section of ArXiv.
+- [ArXiv Machine Learning Landscapa - Leland McInnes](https://lmcinnes.github.io/datamapplot_examples/ArXiv_data_map_example.html) - Visualization showcasing the landscape of machine learning research on ArXiv.
+- [DataMap Landscape - Leland McInnes](https://lmcinnes.github.io/datamapplot_examples/arXiv/) - A collection of examples and demonstrations for visualizing data on manifolds using the DataMapPlot library, focusing on arXiv datasets.
+
+### Infographic
+
+- [Information is Beautiful](https://informationisbeautiful.net/) - Platform focusing on fact- and data-based decisions, presenting information through visually appealing graphics.
+- [Visual Capitalist](https://www.visualcapitalist.com/) - Source of data-driven visuals covering various topics such as markets, technology, energy, and the global economy.
+- [Infographic Journal](https://infographicjournal.com/) - Archive of infographics covering a wide range of topics.
+- [D3.js](https://d3js.org/) - JavaScript library for manipulating documents based on data, enabling the creation of dynamic and interactive data visualizations.
+- [Deniz Cem On Duygu Portfolio](https://www.denizcemonduygu.com/) - Personal portfolio of infographics.
+- [Data Visualization Catalogue](https://datavizcatalogue.com/index.html) - Catalog providing information on various types of data visualizations.
+- [Tableau Public](https://public.tableau.com/app/discover) - Free platform to explore, create, and publicly share data visualizations online.
+- [Will Robots Take My Job?](https://willrobotstakemyjob.com/) - Estimates the automation risk, growth, wages, and more for various jobs.
+- [Preceden](https://www.preceden.com/) - Online timeline and roadmaps maker.
+- [Jason Davies](https://www.jasondavies.com/) - Personal website of Jason Davies showcasing his projects and visualizations.
+
+### Philosophy
+
+- [Desolhar Philo](https://www.desolhar-philo.com/) - Notes about philosophy.
+- [VisualizingSEP](https://www.visualizingsep.com/) - Interactive visualization and search engine for exploring the Stanford Encyclopedia of Philosophy.
+- [Hakob's Sandbox](https://hakobsandbox.openetext.utoronto.ca/) - Online book on the introduction to the history and philosophy of science.
+- [Philosophy A Level](https://philosophyalevel.com/)
+- [Deniz Cemon Duygu - History of Philosophy](https://www.denizcemonduygu.com/philo/browse/) - Summarized & Visualized.
+- [Interactive timeline of philosophical ideas](https://www.denizcemonduygu.com/portfolio/the-history-of-philosophy/). - Visual representation and exploration of the significant philosophers and their ideas.
+- [Beyng](https://www.beyng.com/) - A resource dedicated to Martin Heidegger's philosophy, providing English translations and discussions of his works and ideas.
+- [Greg Egan's Official Website](https://www.gregegan.net/) - Information about the works, philosophy, and projects of science fiction author and computer programmer Greg Egan is presented.
+- [Ayn Rand Institute Courses](https://courses.aynrand.org/) - Educational platform offering free courses on Ayn Rand's philosophy, including Objectivism and its application to life and society.
+
+### Social Sciences
+
+- [Temple Manifold - All Projects](https://temple.manifoldapp.org/projects/all) - A collection of great resources on various social sciences.
+
+### History
+
+- [Histography](https://histography.io/) - An interactive timeline that spans across 14 billion years of history, from the Big Bang to 2015.
+- [Unenumerated Blog](https://unenumerated.blogspot.com/) - A comprehensive and highly detailed blog covering various history topics.
+- [Human Origins - Human Family Tree](https://humanorigins.si.edu/evidence/human-family-tree) - An interactive Human Family Tree that explores the evolutionary history of humans.
+- [OldEra Timeline](https://timeline.oldera.org/) - An interactive timeline that allows you to view the entire history on a zoomable interface.
+- [Nuclear Secrecy Blog](https://blog.nuclearsecrecy.com/) - Historical information about nuclear secrecy, providing insights into the development and implications of nuclear weapons.
+- [The Ascent of Humanity](https://ascentofhumanity.com/) - Explores the concept of the Age of Separation, the Age of Reunion, and the convergence of crises shaping the transition in human history.
+- [Today in Science History](https://todayinsci.com/) - Platform offering historical events of a given date.
+- [Khipu Field Guide](https://khipufieldguide.com/guidebook/Introduction.html) - Guidebook providing information on khipus, the ancient Incan system of knotted strings for record-keeping.
+- [Hellenistic History](https://www.hellenistichistory.com/) - Resource for the study of Hellenistic history, covering the political, cultural, and social developments from Alexander the Great's era to the Roman Empire.
+- [Perseus Digital Library](https://www.perseus.tufts.edu/hopper/) - Provides a vast collection of classical texts, images, and resources for the study of ancient Greek and Roman cultures.
+- [Futility Closet](https://www.futilitycloset.com/) - Collection of entertaining curiosities in history, literature, language, art, philosophy, and mathematics, designed to help you waste time as enjoyably as possible.
+
+### Geoscience
+
+- [River Runner Global](https://river-runner-global.samlearner.com/) - Offers a visualization of the path of a rain droplet from any point in the world to its end point.
+- [Celestrak Satellite Visualization](https://celestrak.com/cesium/orbit-viz.php?tle=/pub/TLE/catalog.txt&satcat=/pub/satcat.txt&referenceFrame=1) - Provides satellite visualization tools.
+- [Mars Now](https://mars.nasa.gov/explore/mars-now/) - Shows the current positions of Mars's satellites, offering insights into Martian exploration.
+- [Physical Geology](https://temple.manifoldapp.org/projects/physical-geology) - Covers essential topics in Physical Geology.
+- [Flood Site](https://floodsite.net/juniorfloodsite/) - An educational resource about flooding.
+- [NEMO - Nucleus for European Modeling of the Ocean](https://www.nemo-ocean.eu/) - Platform providing information and resources related to ocean modeling for multifarious space and time scales, developed by a European consortium.
+- [USGS Earthquake Map](https://earthquake.usgs.gov/earthquakes/map/?extent=25.56227,4.08691&extent=45.08904,70.00488&list=false) - Map displaying recent earthquake activity from the United States Geological Survey.
+- [LatLong.net](https://www.latlong.net/) - Tool for finding latitude and longitude coordinates for any location on a map, providing geographic coordinates and related data.
+- [Latitude.to](https://latitude.to/) - Allows users to find GPS coordinates for any address or location worldwide, with detailed mapping features.
+
+### Biology
+
+- [Sectional Anatomy](https://www.sectional-anatomy.org/) - Free online tool for radiologic cross-sectional anatomy.
+- [Deep Sea](https://neal.fun/deep-sea/) - Platform to explore the depths of the seas.
+- [Ask Nature](https://asknature.org/) - Biology-inspired strategies, innovations, or educational resources.
+- [We Are Hosts for Memes](https://wearehostsformemes.com/) - You have been exposed to The Meta-meme
+- [Birdwatching Zone](https://birdwatching.zone/) - A site dedicated to birdwatching, featuring over 300 species recorded with identification tips and resources for enthusiasts.
+- [OneZoom](https://www.onezoom.org/) - The Tree of Life that illustrates how all life on Earth is connected. Explore relationships between 2.2 million species, view over 100,000 images, and see how species evolved from common ancestors. Zoom through the tree to discover the diversity of life on Earth.
+
+## Physics
+
+- [The Theoretical Minimum](https://theoreticalminimum.com/home) - Series of Stanford Continuing Studies courses taught by world-renowned physicist Leonard Susskind.
+- [Theoretical Physics - Cambridge](https://www.damtp.cam.ac.uk/user/tong/index.html) - Resources and information about theoretical physics from the University of Cambridge.
+- [University of Virginia Classical and Modern Physics II](https://galileo.phys.virginia.edu/classes/632.ral5q.summer06/lectures.html) - Lecture notes and materials for the Classical and Modern Physics II course at the University of Virginia.
+- [Mueller Group - Cornell](https://muellergroup.lassp.cornell.edu/index.html) - Laboratory of Atomic and Solid State Physics at Cornell University.
+- [Ptable](https://ptable.com/?lang=en) - Interactive and customizable periodic table providing information about elements and their properties.
+- [National Institute of Standards and Technology – Fundamental Physical Constants](https://www.nist.gov/pml/fundamental-physical-constants) - Offers authoritative data on physical constants, providing essential measurements for research and technological applications.
+- [Mechanics Map](https://mechanicsmap.psu.edu/index.html) - Interactive resource from Penn State University for exploring mechanical systems and understanding basic mechanics principles.
+
+### Quantum
+
+- [Quasihome Interference](https://vsg.quasihome.com/interfer.htm) - Applet of Young's Double Slit Interference
+
+#### Quantum Games
+
+- [Virtual Lab by Quantum Flytrap](https://quantumflytrap.com/lab) - Simulates optical experiments with multiparticle quantum systems, supporting quantum key distribution and entanglement exploration.
+- [Hello Quantum](https://quantum-computing.ibm.com/lab) - Introduces quantum circuits and gates via interactive puzzle games, featuring graphical interfaces to simplify quantum concepts.
+- [Particle in a Box](https://learnqm.gatech.edu) - Demonstrates quantum superposition and energy levels through a 2D single-player platformer contrasting classical and quantum physics.
+- [Psi and Delta](https://learnqm.gatech.edu) - Encourages collaborative learning of quantum mechanics using cooperative gameplay focused on superposition and quantum probabilities.
+- [QPlayLearn](https://qplaylearn.com) - Offers interactive tools, videos, and games for multi-level education on quantum physics, addressing diverse learner profiles.
+- [Quantum Odyssey](https://quarksinteractive.com) - Visualizes quantum algorithm development through a game-like interface, aiding education in quantum computing logic and state evolution.
+- [Quantum Moves 2](https://www.scienceathome.org/games/quantum-moves-2) - Engages citizen scientists in optimizing quantum experiments, addressing real-world challenges in quantum optimization.
+- [The Virtual Quantum Optics Laboratory](https://www.vqol.org/) - Enables design and simulation of quantum optics experiments, bridging classical and quantum mechanics for educational use.
+- [Arxiv Paper - Quantum Games and Interactive Tools for Quantum Technologies Outreach and Education](https://arxiv.org/abs/2202.07756) - Comprehensive discussion of the use of games and interactive tools to engage the public in understanding quantum technologies.
+
+### Astronomy
+
+- [Fear of Physics](https://www.fearofphysics.com/) - Offers a free "Astronomy 101" course.
+- [Galileo's Applets](https://galileo.phys.virginia.edu/classes/109N/more_stuff/Applets/home.html) - Provides applets on early lunar observations and various motion-related topics.
+- [100,000 Stars](https://stars.chromeexperiments.com/) - A visualization of 100,000 nearby stars, providing an immersive experience.
+- [The Million Earth Solar System](https://planetplanet.net/2018/06/01/the-million-earth-solar-system/) - Explores the concept of a solar system with a million Earth-like planets.
+- [Space Telescope Live](https://spacetelescopelive.org/webb) - Live access to real-time data and observations from the James Webb Space Telescope, allowing users to explore space research and discoveries.
+- [Telescope Optics](https://www.telescope-optics.net/) - A resource for amateur telescope builders, providing detailed information on designing and constructing telescope optics.
+- [Orbital Basics](https://t-neumann.github.io/space/OrbitalBasics/) - Educational resource explaining the fundamental concepts of orbital mechanics, designed for beginners in space science.
+- [Webb Telescope](https://webbtelescope.org/) - Official website for the James Webb Space Telescope.
+
+## Mathematics
+
+- [Open Logic Text](https://openlogicproject.org/about/) - Open-source, modular, collaboratively authored collection of teaching materials for formal (meta)logic and formal methodss.
+- [OEIS - The On-Line Encyclopedia of Integer Sequences](https://oeis.org/) - Platform providing a comprehensive database of integer sequences.
+- [First Principles of Mathematics](https://pdodds.w3.uvm.edu/) - Resource covering first principles of various math topics.
+- [38 Best Math Websites for Students](https://blog.symbaloo.com/webmixes/11/best-math-websites) - Compilation of 38 recommended math websites for students.
+- [Math Hints](https://mathhints.com/) - Free website with simple explanations and examples for various math topics.
+- [Better Explained](https://betterexplained.com/) - Platform focusing on understanding math concepts rather than memorization, with clear lessons on topics like imaginary numbers and exponents.
+- [Mathway](https://www.mathway.com/) - Free math problem solver.
+- [ChiliMath](https://www.chilimath.com/) - Online resource for math topics.
+- [Visual and Interactive Introduction to Complex Analysis](https://complex-analysis.com/) - Resource providing a visual and interactive introduction to complex analysis.
+- [Matrices as Tensor Network Diagrams](https://www.math3ma.com/blog/matrices-as-tensor-network-diagrams) - Article discussing matrices represented as tensor network diagrams.
+- [What is Category Theory Anyway?](https://www.math3ma.com/blog/what-is-category-theory-anyway) - Exploring the grand scheme of mathematical things with category theory.
+- [Algebra Practice Problems](https://www.algebrapracticeproblems.com/) - Platform offering algebra practice problems with clear explanations.
+- [Matrixology](https://pdodds.w3.uvm.edu/teaching/courses/2016-08UVM-122/) - Matrixology course resource.
+- [Math Courses at NITK](https://sam.nitk.ac.in/courses-taught.html) - List of math courses taught at the National Institute of Technology Karnataka (NITK).
+- [Easy Mathematical Tricks from Counting Through Calculus](https://mathhints.com/) - Collection of easy mathematical tricks from counting through calculus.
+- [Math Salamanders](https://www.math-salamanders.com/) - Platform providing useful calculators (like Reverse Percentage Calculator) and math worksheets for kids or students.
+- [3Blue1Brown Non-Videos](https://some.3b1b.co/non-videos) - Non-video content winners of 3Blue1Brown's SoME.
+- [Mathigon – The Mathematical Playground](https://mathigon.org/) - Interactive mathematics platform offering educational content and resources.
+- [Math Warehouse](https://www.mathwarehouse.com/) - Offers interactive math activities, demonstrations, lessons with definitions and examples, worksheets, and other resources.
+- [Cut the Knot](https://www.cut-the-knot.org/) - Resource offering interactive math puzzles, problems, and visualizations to explore mathematical concepts through problem-solving.
+- [Trigonography](https://trigonography.com/?page_id=230) - Site exploring trigonometry and its applications, featuring visual aids, formulas, and problem-solving techniques.
+- [Lamar Math Tutorials](https://tutorial.math.lamar.edu/) - A comprehensive collection of math tutorials and practice problems, covering topics from algebra to calculus and differential equations.
+- [Art of Problem Solving](https://artofproblemsolving.com/company) - Focuses on developing problem-solving skills across various subjects including mathematics, physics, programming, and language arts. Offers rigorous online classes, physical academies, and an engaging curriculum designed to encourage critical thinking, experimentation, and perseverance in students.
+- [Mathematics Genealogy Project](https://genealogy.math.ndsu.nodak.edu/index.php) - Aims to compile and share comprehensive information on mathematicians worldwide, gathering data from academic institutions and individual contributors.
+- [Enjeck Complicated Math Equation Generator](https://enjeck.com/num2math/?input=4&submit=Generate) - Generates complex mathematical equations based on user input, offering a tool for practicing or visualizing mathematical problems.
+- [Erdos Problems](https://www.erdosproblems.com/) - A site dedicated to exploring open mathematical problems related to Paul Erdős, including ongoing challenges in number theory and combinatorics.
+- [The Electronic Journal of Combinatorics](https://www.combinatorics.org/ojs/index.php/eljc) - An open-access journal publishing research papers and articles on combinatorics, an area of mathematics dealing with counting, arrangement, and structure.
+- [Zeta by Amir Hirsch](https://amirhirsch.com/zeta/index.html) - Website dedicated to the exploration of the Riemann Hypothesis, with interactive tools and resources for those interested in number theory.
+- [Tungsteno](https://www.tungsteno.io/) - A platform providing pedagogical tools to make mathematics accessible to everybody, completely free, based on open collaboration.
+- [PlanetMath](https://planetmath.org/) - Online mathematical resource and collaborative platform that provides open-access mathematics content, including definitions, theorems, and proofs.
+- [Geomstats Tutorials](https://geomstats.github.io/tutorials/index.html) - Tutorials and resources on geometric statistics, providing practical examples and code for implementing statistical techniques on manifolds.
+- [Ximera - MOOCulus](https://ximera.osu.edu/mooculus) - Collection of interactive math modules and learning resources designed for online courses, focusing on calculus and related subjects.
+- [EuclideanSpace](https://euclideanspace.com) - Topics in mathematics and computing explained through visualizations and detailed references.
+
+### Math + Art
+
+- [Paul Nylander's website](https://bugman123.com/) - Favorite hobbies and interests, especially science, and art of Paul Nylander
+- [NYC DOE CS4All](https://nycdoe-cs4all.github.io/) - Introduction to Computational Media with p5.js
+- [Texample](https://texample.net/) - Examples and community of LaTeX
+- [Snowflakes Project](https://www.dynamicmath.xyz/collective-math-art/) - Snowflakes project by Collective Mathematical Art
+
+## Engineering
+
+- [Animagraffs](https://animagraffs.com/) - Educational website featuring detailed animated infographics (animagraffs) that visually explain complex topics and processes across various subjects.
+- [Technology Student](https://technologystudent.com/index.htm) - A resource containing numerous information sheets, exercises, and animations, covering various technology-related topics.
+- [Nuclear Power](https://www.nuclear-power.com/) - A non-profit project aimed at learning the basics of nuclear and reactor physics, covering topics such as nuclear power plants, reactor physics, thermal engineering, materials, and radiation protection.
+- [Knovel](https://app.knovel.com/kn) - A platform providing tools and calculators for various engineering and scientific purposes.
+- [Engineering Library](https://engineeringlibrary.org/reference/) - Reference library for engineering topics.
+- [Engineering Toolbox](https://www.engineeringtoolbox.com/index.html) - Online resource providing engineering tools and information.
+- [Text to CAD](https://text-to-cad.zoo.dev/) - Tool converting textual descriptions into CAD models, helping users generate technical drawings from written input.
+- [McMaster-Carr](https://www.mcmaster.com/) - Supplier of hardware, tools, raw materials, industrial materials, and maintenance equipment, serving a wide range of industries with an extensive catalog of products.
+- [Engineer on a Disk: Modeling](https://engineeronadisk.com/book_modeling/modelTOC.html) - A book offering a hands-on guide to system modeling and simulation, with practical examples and explanations for engineers and developers.
+- [Bartosz Ciechanowski Archives](https://ciechanow.ski/archives/) - Collection of articles on design and technology by Bartosz Ciechanowski.
+- [IQS Directory Articles](https://www.iqsdirectory.com/articles/) - Industrial components explained through technical articles and manufacturer insights.
+
+### Civil Engineering
+
+- [Floor Plan Lab](https://floorplanlab.com/) - Platform for creating and visualizing floorplans.
+- [Engineers Edge](https://www.engineersedge.com/) - Platform providing articles and resources on structural and mechanical engineering topics.
+- [3D House Planner](https://3dhouseplanner.com/) - Free 3D floor planner application on the web.
+
+### Mechanical Engineering
+
+- [507 Movements](https://507movements.com/toc.html) - Website featuring animated mechanical movements, providing a visual understanding of various mechanical systems.
+- [MadeHow](https://www.madehow.com/) - Resource explaining and detailing the manufacturing processes of a wide variety of products.
+- [Comprehensive Structural Analysis Book](https://temple.manifoldapp.org/projects/structural-analysis) - Online resource offering a comprehensive book on structural analysis.
+- [Awesome MechEng](https://github.com/m2n037/awesome-mecheng#heat-transfer) - Awesome Mechanical Engineering Resources.
+- [Animated Dynamics](https://dynref.engr.illinois.edu/ref.html) - Interactive reference for visualizing dynamics simulations, aimed at helping users better understand complex mechanical systems.
+- [Wikimedia Commons - Engine Animations](https://commons.wikimedia.org/wiki/Category:Animations_of_engines) - A collection of animated images and videos that demonstrate the functioning of various types of engines, from combustion to electric.
+- [Mechanisms/menu-gear](https://www.mekanizmalar.com/menu-gear.html) - Gear mechanisms animated.
+- [Mechanism Animations](https://people.ohio.edu/williams/html/MechanismAnimations.html) - Offers interactive animations that demonstrate mechanical systems and mechanisms, helping users visualize and understand their motion and function.
+- [CalcResource](https://calcresource.com/resources.html) - Regularly updated list of resources focused on mechanics and statics, aiding in learning and understanding these subjects.
+- [Engineering Toolbox](https://www.engineeringtoolbox.com/) - Comprehensive resource covering a wide range of engineering topics.
+- [StructX](https://structx.com/) - Website offering structural engineering resources for professionals and students.
+- [Amesweb](https://www.amesweb.info/) - Platform with calculators and articles covering various engineering topics.
+- [RoyMech](https://www.roymech.co.uk/) - Reference site with in-depth articles on structural and mechanical engineering subjects.
+- [Arcelor-Mittal Design Software](https://sections.arcelormittal.com/design_aid/design_software/EN) - Free design software for steel structures provided by Arcelor-Mittal.
+- [BU Moss](https://www.bu.edu/moss/) - Courses and resources focused on understanding slender structures.
+- [Homestyler](https://www.homestyler.com/) - Easy and time-saving online interior design tool catering to both professionals and amateurs.
+- [How a Car Works](https://www.howacarworks.com/) - Complete and free guide explaining how cars work.
+- [IIHS Ratings](https://www.iihs.org/ratings) - Crash test ratings and safety information from the Insurance Institute for Highway Safety.
+- [Euro NCAP](https://www.euroncap.com/en/) - European New Car Assessment Programme providing safety ratings for vehicles.
+- [Toaster Museum](http://toastermuseum.com/) - A dedicated collection of antique toasters, showcasing vintage models for toaster enthusiasts and collectors, along with historical information and preservation details.
+
+#### Materials / Nanotechnology
+
+- [DoITPoMS](https://www.doitpoms.ac.uk/index.php) - DoITPoMS from Department of Materials Science and Metallurgy, University of Cambridge
+- [Nanoscience Resources](https://ssd.phys.strath.ac.uk/) - Nanoscience resources of the Department of Physics at the University of Strathclyde
+- [StatNano](https://product.statnano.com/) - Reliable source of information about nanotechnology products, currently used in a broad range of industrial applications
+- [MyMiniFactory](https://www.myminifactory.com/) - World’s largest ecosystem of free to download, 3D printable objects of cultural significance
+- [Roy Mech](https://roymech.org/) - This site provides useful information, tables , schedules and formula related to mechanical engineering and engineering materials.
+
+### Electronics Engineering
+
+- [Electrical4U](https://www.electrical4u.com/) - Platform for learning electrical engineering.
+- [Electronics Tutorials](https://www.electronics-tutorials.ws/) - Resource providing tutorials on various aspects of electronics.
+- [Octopart](https://octopart.com/) - Search engine for electronic and industrial parts. It aggregates parts from distributors and manufacturers online, making them easy to search for and purchase.
+- [TechSpot - How CPUs Are Designed and Built](https://www.techspot.com/article/1821-how-cpus-are-designed-and-built/) - Series covering computer architecture, processor circuit design, VLSI, chip fabrication, and future trends in computing.
+- [Open Circuits Book](https://www.opencircuitsbook.com/) - "Open Circuits" is a photographic exploration of the beautiful design inside everyday electronics.
+- [Digi-Key Electronics](https://www.digikey.com/) - Online marketplace for electronic components, featuring a vast selection of parts, tools, and resources for engineers and makers.
+- [Telematic Connections Timeline](http://telematic.walkerart.org/timeline/index.html) - Interactive timeline exploring the history and impact of telematics and networked communication, with a focus on art and technology.
+- [Cybergraph](https://cybergraph.dubberly.com/#) - Visual exploration of Cybernetics, offering interactive representations of networks.
+- [EveryCircuit](https://everycircuit.com/) - Electronic circuits simulated and visualized in real time with interactive component behavior.
+- [Falstad Circuit Simulator](https://www.falstad.com/circuit/) - Electronic circuits modeled and tested in-browser using animated schematic diagrams.
+
+## Computer Science
+
+- [Webopedia](https://www.webopedia.com/) - Online tech dictionary, study guides, and reviews for computer and IT terms.
+- [Teach Yourself Computer Science](https://teachyourselfcs.com/) - Comprehensive guide for self-study in computer science.
+- [Open Source Society University - Computer Science](https://github.com/open-source-society/computer-science) - Curriculum for computer science studies provided by the Open Source Society University.
+- [Functional Computer Science Curriculum](https://functionalcs.github.io/curriculum/) - Curriculum focusing on functional programming concepts in computer science.
+- [Menimagerie](https://www.menimagerie.com/) - Explore concepts in theoretical computer science, from the number system to Cantor infinities, Godel's theorems, and automat.
+- [Computer Science Library](https://www.compscilib.com/) - Platform aiding in mastering concepts in computer science and math courses with automated step-by-step solutions and practice problems.
+- [Computer Jargon](https://www.computerhope.com/jargon.htm) - Glossary of computer-related jargon and technical terms.
+- [Talks by Alan Kay](https://tinlizzie.org/IA/index.php/Talks_by_Alan_Kay) - Collection of talks by computer scientist Alan Kay.
+- [Everything Computer Science](https://everythingcomputerscience.com/) - A wide range of articles and tutorials on computer science topics, including programming, algorithms, data structures, and software development practices.
+- [Richard Sutton Video Lectures](https://videolectures.net/search/?query=Richard%20sutton) - Collection of video lectures and talks by Richard Sutton, a prominent researcher in reinforcement learning and artificial intelligence.
+
+### Data Structures and Algorithms (DS&A)
+
+- [Dictionary of Algorithms and Data Structures](https://xlinux.nist.gov/dads/) - NIST's Dictionary of Algorithms and Data Structures.
+- [Visualgo](https://visualgo.net/en) - Platform for visualizing data structures and algorithms through animations.
+- [Adventures In Coding & Algorithms](https://entcheva.github.io/) - Blog exploring coding and algorithms.
+- [Damn Cool Algorithms](https://blog.notdot.net/tag/damn-cool-algorithms) - Blog featuring posts on particularly interesting algorithms.
+- [Skiena's Algorithms Lectures](https://www3.cs.stonybrook.edu/~algorith/video-lectures/) - Video lectures on algorithms by Steven Skiena.
+- [Visual Algorithms](https://thimbleby.gitlab.io/algorithm-wiki-site/) - Platform presenting visual representations of algorithms.
+- [Sinon - Algorithms](https://sinon.org/algorithms/) - Summarized page covering important results from computer science.
+
+### Big-O notation
+
+- [Algorithms and Data Structures Big-O Notation](https://cooervo.github.io/Algorithms-DataStructures-BigONotation/) - Comprehensive resource covering Big-O notation for various algorithms and data structures.
+- [Big-O Cheat Sheet](https://www.bigocheatsheet.com/) - Webpage presenting the space and time complexities (Big-O) of common algorithms used in Computer Science.
+- [Comp160 Data Cheat](https://www.clear.rice.edu/comp160/data_cheat.html) - Resource providing information on data structures and related concepts in computer science.
+
+## AI/ML
+
+- [Doublespeak Chat](https://doublespeak.chat/#/handbook) - Empirical, non-academic, and practical guide to LLM hacking.
+- [Fast.ai Course](https://course.fast.ai/) - Online course for deep learning and machine learning.
+- [Papers with Code](https://paperswithcode.com/sota) - Collection of state-of-the-art results for machine learning tasks with associated code.
+- [Delta Academy Maps](https://maps.joindeltaacademy.com/) - Map of mathematics for Machine Learning.
+- [Inside the Matrix by PyTorch](https://pytorch.org/blog/inside-the-matrix/) - Blog post by PyTorch that is visualizing matrix multiplication, attention and beyond.
+- [Directory of AI Models](https://docs.google.com/spreadsheets/d/1gc6yse74XCwBx028HV_cvdxwXkmXejVjkO-Mz2uwE0k/edit?pli=1#gid=0) - Google Sheets document providing a directory of various AI models, presenting information such as name, date, parameters, organization, organization type, author location, language, commercial use, model, accessibility, code accessibility, data accessibility, major datasets used, and architecture.
+- [Papers with Code](https://paperswithcode.com/) - Platform providing the latest in machine learning research papers along with code implementations and benchmarks.
+- [Globe Engineer Explorer](https://explorer.globe.engineer/) - Applied AI company making products that optimally represent information for human comprehension.
+- [Colah's Blog](https://colah.github.io/) - Blog by Christopher Olah on deep learning and artificial intelligence, featuring detailed explanations, tutorials, and research insights.
+- [TensorFlow Playground](https://playground.tensorflow.org) - An interactive tool for experimenting with neural networks, allowing users to visualize how different configurations affect model training and classification tasks.
+- [Ben's Bites](https://bensbites.com/catalog) - Catalog offering a variety of bite-sized AI resources.
+
+### Robotics
+
+- [Robots Guide](https://robotsguide.com/) - A comprehensive resource offering guides, reviews, and insights on robotics, aimed at both beginners and enthusiasts in the world of robotics.
+- [Control Challenges](https://janismac.github.io/ControlChallenges/) - Leetcode for robotics.
+
+### LLMs
+
+- [Hacker Llama](https://osanseviero.github.io/hackerllama/blog/posts/hitchhiker_guide/) - Blog post on the useful terms to know when joining the Local LLM community.
+- [Moebio Mind](https://moebio.com/mind/) - Explores the inner workings of language models, visualizing the semantic space and trajectories of word completions generated by the GPT-3 API. The site demonstrates how responses evolve through high-dimensional spaces and presents interactive visualizations of word sequences and their probabilities, offering a unique perspective on machine-generated intelligence.
+- [LLM Visualization](https://bbycroft.net/llm) - Interactive tool for visualizing large language models (LLMs) and exploring their structure, behavior, and outputs.
+- [RR LM Game](https://rr-lm-game.herokuapp.com/) - Browser-based Language modelling game.
+
+#### Prompt Engineering
+
+- [PromptPerfect](https://promptperfect.jina.ai/) - Cutting-edge prompt optimizer designed for large language models (LLMs), large models (LMs), and LMOps.
+- [Jailbreak Chat](https://www.jailbreakchat.com/) - Jailbreak collection for LLMs.
+- [MidJourney Styles and Keywords Reference](https://github.com/willwulfken/MidJourney-Styles-and-Keywords-Reference) - Styles and keywords for AI image generation.
+- [QuickRef ChatGPT](https://quickref.me/chatgpt) - ChatGPT cheatsheet.
+- [OpenAI Cookbook](https://cookbook.openai.com/) - Cookbook by OpenAI providing practical guides for working with AI.
+- [Prompting Guide](https://www.promptingguide.ai/) - Resource for creating effective prompts for AI models.
+- [Instaprompt](https://www.instaprompt.ai/?ref=producthunt) - Platform offering instant prompts for writing.
+- [Midjourney Prompt Helper](https://promptfolder.com/midjourney-prompt-helper/) - Assists users in generating detailed and effective prompts for Midjourney, enabling the creation of high-quality images through natural language inputs.
+- [Free Midjourney Prompt](https://www.freemidjourneyprompt.com/) - Offers a wide selection of free Midjourney prompts, allowing users to easily generate images by providing optimized natural language prompts.
+- [Prompt Engineering Guide](https://learnprompting.org/docs/introduction) - Serves as a comprehensive guide to prompt engineering, offering essential principles and techniques for crafting effective prompts for AI models and creative tasks.
+
+### AI tools
+
+- [Future Tools](https://www.futuretools.io/) - Platform for finding the exact AI tool for your needs.
+- [WarpSound AI](https://www.warpsound.ai/) - Create high-quality generative AI music in seconds with just prompts.
+- [AI Tools Arena](https://aitoolsarena.com/) - Platform showcasing various AI tools and resources.
+- [Klavier AI](https://klavier.ai/) - Allows you to do Q&A with ChatGPT on web pages and docs you choose.
+- [Aiva Valley](https://aivalley.ai/) - The latest source of AI tools and prompts.
+- [Bardeen AI](https://www.bardeen.ai/) - Automate manual work and tasks with AI without any code in minutes.
+- [Speechify](https://speechify.com/) - Power through documents, articles, PDFs, email—anything you read—by listening with their leading AI text-to-speech reader.
+- [Humata AI](https://www.humata.ai/) - Upload any PDF or document and get answers from it in seconds.
+- [Syntelly](https://app.syntelly.com/search) - Artificial intelligence for organic and medical chemistry.
+- [Warp.dev - Warp AI](https://www.warp.dev/warp-ai?source=producthunt&ref=producthunt) - AI-powered tool for building APIs without writing code.
+- [Feedback by AI](https://feedbackbyai.com/?ref=producthunt) - Platform utilizing AI for generating actionable feedback on writing.
+- [Seeing the World through Your Eyes](https://world-from-eyes.github.io/) - Reconstruct the world that is reflected through human eyes.
+- [Auxiliary Tools](https://www.auxiliary.tools/) - Platform offering AI experiments and tools for humans.
+- [Hemingway Editor](https://hemingwayapp.com/) - Spellchecker, but for style.
+- [FuturePedia](https://www.futurepedia.io/) - Leading AI resource platform dedicated to empowering professionals across various industries to leverage AI technologies for innovation and growth.
+- [ExplainPaper](https://www.explainpaper.com/) - Platform where users can upload a research paper, highlight confusing text, and receive an explanation to make research papers easier to read.
+- [Summarize Tech](https://www.summarize.tech/) - AI-powered tool to get a summary of any long YouTube video, such as lectures, live events, or government meetings.
+- [YouTubeTranscript](https://youtubetranscript.com/) - Get a YouTube video transcript and summaries
+
+### Data Science
+
+- [DataTau](https://www.datatau.com/news) - Hackernews but for data
+- [DatasetList](https://www.datasetlist.com/) - List of machine learning datasets from across the web
+- [Stat Learning](https://www.statlearning.com/) - Platform for learning statistics and related topics.
+
+### Databases
+
+- [ImageNet](https://www.image-net.org/) - Image database organized according to the WordNet hierarchy.
+- [DataSheets.com](https://www.datasheets.com/) - Searchable database of electronic component datasheets and purchasing information, designed for design engineers and electronics purchasing agents.
+- [Academic Torrents](https://academictorrents.com/) - Community-driven platform for sharing large datasets, offering torrents for academic research, including scientific papers, datasets, and multimedia.
+- [DBLP](https://dblp.org/) - Comprehensive, open-access database providing bibliographic information on major computer science journals, conferences, and proceedings.
+
+## Web Development
+
+- [Mozilla Developer Network](https://developer.mozilla.org/en-US/) - Documentation for web technologies, including CSS, HTML, and JavaScript.
+- [W3C](https://www.w3.org/) - World Wide Web Consortium's official website, making it possible to use web technologies with different languages, scripts, and cultures.
+- [UX Core](https://keepsimple.io/uxcore) - UX Core allows you to explore many cognitive biases while creating software.
+- [Coggle](https://coggle.it/diagram/Vz9LvW8byvN0I38x/t/web-development) - Collaborative mind-mapping tool for visualizing and organizing ideas related to web development.
+- [Web.dev Learn](https://web.dev/learn) - Educational platform by Google providing resources and tutorials for web development.
+- [WebDevHome](https://webdevhome.github.io/) - Collection of web development resources and tutorials.
+- [Web Dev Resources](https://web-dev-resources.com/#/) - Curated list of awesome web development resources for developers.
+- [BBC Microbit Editor](https://bbcmic.ro/) - Basic editor from BBC for Microbit programming.
+- [DemoFox](https://blog.demofox.org/) - Blog with various links related to programming and development.
+- [Timeline of Web Browsers](https://super-static-assets.s3.amazonaws.com/bc2689f0-a124-4777-93dc-416ee1aa4858/images/7db6532c-14f1-4c51-a337-b3021a7293bf.svg) - Visualization of the timeline of web browsers until 2019.
+- [Is Houdini Ready Yet?](https://ishoudinireadyyet.com/) - Tool to check the readiness status of various Houdini specifications in web browsers.
+- [Artillery](https://www.artillery.io/) - Modern load testing and smoke testing tool for SRE (Site Reliability Engineering) and DevOps.
+- [Rentry](https://rentry.org/) - Markdown pastebin service with preview, custom URLs, and editing, offering fast, simple, and free use with entries kept forever.
+- [Intab Resources](https://intab.io/resources/) - Curated Web Dev Tools 2021.
+- [Chrome Extension Kit](https://chromeextensionkit.com/) ($) - Kit including 17 battle-tested starter templates for building Chrome Extensions, saving time on setup and focusing on shipping.
+- [Esoteric Codes](https://esoteric.codes/) - Platform exploring esoteric programming languages (esolangs), constraint-based coding, code art, code poetry, and more.
+- [FreeFormatter](https://freeformatter.com/) - Free online tools for developers, including formatters, validators, code minifiers, string escapers, encoders/decoders, message digesters, and more.
+- [dbdesigner.net](https://www.dbdesigner.net/) - Online database schema design and modeling tool for free.
+- [Jvns blog](https://jvns.ca/blog/2022/04/12/a-list-of-new-ish--command-line-tools/>) - A list of new(ish) command line tools
+- [VisBug](https://visbug.web.app/) - Open-source browser design tools for web development.
+- [Web Design Repo](https://webdesignrepo.com/) - Repository of free web design resources for designers and developers.
+- [Devopedia](https://devopedia.org/) - Knowledge hub covering various topics related to technology and software development.
+- [MadeWithBubble](https://www.madewithbubble.xyz/) - Platform to discover interesting apps and websites created with Bubble, a visual web development platform.
+- [Interneting is Hard](https://www.internetingishard.com/) - Friendly web development tutorials designed for complete beginners.
+- [Airtable Toolkit](https://www.airtable.com/home/toolkit) - Platform allowing users to build apps that connect different parts of their work, ensuring synchronization within the business.
+- [Grey Software Resources](https://resources.grey.software/) - Up-to-date software resources curated and crowd-sourced by professionals and academics worldwide.
+- [Free-for.dev](https://free-for.dev/#/) - List of software (SaaS, PaaS, IaaS, etc.) and other offerings that have free tiers for developers.
+- [Free Privacy Policy Generator](https://www.freeprivacypolicy.com/) - Tool to generate a free privacy policy, ensuring compliance with requirements from CCPA, GDPR, CalOPPA, Google Analytics & AdSense, and more.
+- [Mailinator](https://www.mailinator.com/) ($) - Platform allowing developers and QA testing teams to test email and SMS workflows, including 2FA verifications, sign-ups, and password resets.
+- [Addy's Toolkit](https://toolkit.addy.codes/) - Collection of 806 hand-picked tools & resources for web designers & developers.
+- [BrowserBench - Speedometer 3.0](https://www.browserbench.org/Speedometer3.0/) - A benchmark tool to measure the performance of web browsers, specifically testing responsiveness and the speed of modern web applications.
+- [UserAgents.me](https://www.useragents.me/) - Provides self-updating list of the latest and most common useragents seen on the web across all device types, operating systems, and browsers. Data is always fresh, updating weekly. This user agent list is perfect for web scrapers looking to blend in, developers, website administrators, and researchers. The most common useragents list is compiled from the user logs data of a number of popular sites across niches and geography, cleansed (bots removed), and enriched with information about the device and browser.
+
+### Domain Names
+
+- [Atlaq](https://atlaq.com/) - Domain name generator.
+- [ICANN Lookup](https://lookup.icann.org/en) - Registration data for domain names and Internet number resources accessed using WHOIS and RDAP protocols.
+
+### Front-end
+
+- [SafeRules](https://anthonyhobday.com/sideprojects/saferules/) - Visual design rules that can be safely followed every time.
+- [Can I Email](https://www.caniemail.com/) - Check email client compatibility for HTML and CSS features.
+- [Egg Gradients](https://www.eggradients.com/) - Collection of gradient background colors.
+- [Frontend Checklist](https://frontendchecklist.io/) - Exhaustive list of all elements you need to have/test before launching your website/HTML page to production.
+- [Frontend Mentor](https://www.frontendmentor.io/) - Platform to solve real-world HTML, CSS, and JavaScript challenges while working to professional designs.
+- [CodePen](https://codepen.io/) - Platform to build, test, and discover front-end code. Explore [topics](https://codepen.io/topics/).
+- [Electron](https://www.electronjs.org/) - Framework to build cross-platform desktop apps with JavaScript, HTML, and CSS.
+- [Homepage Gallery](https://homepage.gallery/) - Gallery featuring 500+ websites for web design inspiration.
+- [HTML Dog](https://htmldog.com/) - Comprehensive resource on HTML, CSS, and JavaScript.
+- [Learn.shayhowe](https://learn.shayhowe.com/) - Learn to code HTML and CSS.
+- [This vs That](https://thisthat.dev/) - Explore the differences between concepts in front-end development.
+- [Know-It-All](https://know-it-all.io/) - List of what you know and what you don't know about web development.
+- [You Might Not Need jQuery](https://youmightnotneedjquery.com/) - jQuery alternatives.
+
+#### HTML
+
+- [Hyperscript](https://hyperscript.org/) - Make websites written in plain-old markup a joy to use.
+- [htmx](https://htmx.org/) - htmx gives you access to AJAX, CSS Transitions, WebSockets, and Server Sent Events directly in HTML, using attributes, so you can build modern user interfaces with the simplicity and power of hypertext.
+
+#### CSS
+
+- [CSS Solid](https://www.csssolid.com/) - CSS references, tutorials, and articles.
+- [CSS-Tricks](https://css-tricks.com/) - Web design community powered by Digital Ocean.
+- [CSS Box Shadow Code Snippet](https://onaircode.com/css-box-shadow-code-snippet/) - Code snippet for creating CSS box shadows.
+
+#### JavaScript
+
+- [The Coding Cards](https://thecodingcards.com/) ($) - JavaScript & Data Structures Flashcards. Essential Coding Concepts with Syntax and Examples.
+- [StandardJS](https://standardjs.com/) - JavaScript style guide, linter, and formatter.
+- [Modern JavaScript Cheatsheet](https://mbeaudru.github.io/modern-js-cheatsheet/) - A cheatsheet for the JavaScript knowledge you will frequently encounter in modern projects.
+- [JSONPlaceholder](https://jsonplaceholder.typicode.com/) - A free fake API for testing and prototyping.
+- [Vue.js Cheat Sheet](https://marozed.com/vue-cheatsheet/) - Cheat sheet for Vue.js.
+- [JS Bin](https://jsbin.com/) - Open-source collaborative web development debugging tool.
+- [JavaScript Event Keycode Info](https://www.toptal.com/developers/keycode) - Information about JavaScript event keycodes.
+- [jsDelivr](https://www.jsdelivr.com/) - Free CDN for open source. Fast, reliable, and automated.
+
+### Back-End
+
+- [RunSidekick](https://www.runsidekick.com/) - Collect traces and generate logs on-demand without stopping & redeploying your applications.
+- [Vantage Instances](https://instances.vantage.sh/) - Compare Amazon's instance types, pricing, and other pages.
+
+#### APIs
+
+- [Public APIs Directory](https://publicapis.dev/) - Discover public APIs
+- [Public APIs on GitHub](https://github.com/public-apis/public-apis) - Collective list of free APIs for use in software and web development
+- [REST API Tutorial](https://www.restapitutorial.com/) - Learn REST
+- [Spotify API Documentation](https://developer.spotify.com/documentation/web-api) - API documentation of Spotify
+- [Stripe API Documentation](https://stripe.com/docs/api) - API documentation of Stripe
+
+#### SQL
+
+- [SQLZoo](https://sqlzoo.net/wiki/SQL_Tutorial) - Learn SQL in stages
+- [Bipp SQL Tutorial](https://bipp.io/sql-tutorial) - Free SQL tutorial
+- [Select Star SQL](https://selectstarsql.com/) - Interactive book for learning SQL
+- [Medium-Hard Data Analyst SQL Interview Questions](https://quip.com/2gwZArKuWk7W) - Collection of SQL interview questions
+- [SQL Translate](https://www.sqltranslate.app/) - SQL to Natural Language and Natural Language to SQL translator. 100% free and open source
+- [Servers for Hackers](https://serversforhackers.com/) - Server Admin for Programmers. Learn server tech for development and production.
+- [SQLable](https://sqlable.com/) - Collection of SQL tools
+
+### Web Analytics
+
+- [Plausible Analytics](https://plausible.io/) - Simple, open source, lightweight and privacy-friendly alternative to Google Analytics
+- [Pirsch](https://pirsch.io/) - An open-source, cookie-free web analytics platform.
+- [Websites Milonic](https://websites.milonic.com/) - Provides neatly reported important data for websites.
+- [WooRank](https://www.woorank.com/) ($) - Website review and SEO checker.
+- [Semji](https://semji.com/) - A platform to improve the ROI of your content by creating high-performing SEO content.
+- [Web.dev](https://web.dev/) - Allows you to measure the performance of your website and provides actionable insights.
+- [Download Time Calculator](https://downloadtimecalculator.com/) - Estimates the time required to download any file based on your transfer speed without actually downloading the file.
+- [W3C Link Checker](https://validator.w3.org/checklink) - Checks links and anchors in web pages or full websites.
+- [URLVoid](https://www.urlvoid.com/) - A website reputation/safety checker, helping detect potentially malicious websites.
+- [SimilarSites](https://www.similarsites.com/) - Helps find similar websites and provides information about their statistics.
+- [LocaBrowser](https://www.locabrowser.com/) - Test how your website looks from different countries in real time.
+- [StatusVista](https://statusvista.com/) - An all-in-one status page for the systems your product depends on.
+- [BuiltWith](https://builtwith.com/) - Discover what technologies websites are built with, using a database of 59,905+ web technologies and over 673 million websites.
+- [CamelCamelCamel](https://camelcamelcamel.com/) - Free Amazon price tracker that monitors millions of products and alerts you when prices drop.
+- [CloudPing](https://cloudping.bastionhost.org/en/) - Perform an HTTP ping to measure network latency from your browser to various cloud data centers around the world.
+- [DownForEveryoneOrJustMe](https://downforeveryoneorjustme.com/) - Check if a website is down.
+- [DownDetector](https://downdetector.in/) - Real-time problem and outage monitoring.
+- [WebhookWizard](https://webhookwizard.com/) - Unlock data with webhooks.
+- [Lighthouse](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk?hl=en) - An open-source, automated tool for improving the performance, quality, and correctness of web apps.
+- [Archive.md](https://archive.md/) - A time capsule for web pages.
+- [Hypothesis](https://web.hypothes.is/) - A conversation layer over the entire web, working everywhere without needing implementation by any underlying site (open community project).
+- [keyword trends ai](https://keywordtrendsai.com/) - AI analysis of popular search keywords.
+
+#### Testing
+
+- [Fast.com](https://fast.com/) - Measures your internet speed, latency, and upload speed.
+- [Pingdom Tools](https://tools.pingdom.com/) ($) - Allows you to test the page load time, analyze it, and find bottlenecks.
+- [GTmetrix](https://gtmetrix.com/) - Analyze how your site performs, identify reasons for slowness, and discover optimization opportunities.
+- [Loader.io](https://loader.io/) - Free load testing service to stress test web apps and APIs with thousands of concurrent connections.
+- [WebPageTest](https://www.webpagetest.org/) - Measure your site's carbon footprint and run No-Code Experiments to find ways to improve.
+- [Azure Speed Test](https://www.azurespeed.com/Azure/Latency) - Tools for testing the speed and latency of Azure services.
+
+## Software Engineering
+
+- [NoviceDock](https://novicedock.com/) - Platform that provides resources and explanations across various software engineering areas.
+- [Morioh](https://morioh.com/) - Social network for developers to discuss topics about bugs and issues, share knowledge and connect the talents of millions of programmers and developers around the world.
+- [Algorithmica - High-Performance Computing](https://en.algorithmica.org/hpc/) - Algorithms for Modern Hardware by Sergey Slotin.
+- [ExBook](https://markm208.github.io/exbook/) - An Animated Introduction to Elixir.
+- [Ben Grosser Projects](https://bengrosser.com/projects/) - Portfolio of projects by Ben Grosser.
+- [Cybercademy Project Ideas](https://cybercademy.org/project-ideas/) - Resource for exploring cybersecurity project ideas, providing inspiration for educational or practical cybersecurity initiatives.
+
+### Android Development
+
+- [Fossdroid](https://fossdroid.com/) - A platform for discovering and sharing open-source Android apps.
+- [Android Weekly](https://androidweekly.net/) - A weekly newsletter with curated news, articles, and resources related to Android development.
+- [F-Droid Repository Search](https://apt.izzysoft.de/fdroid/index.php) - Allows you to search for apps available on the F-Droid repository, a collection of free and open-source Android apps.
+- [Exodus Privacy](https://reports.exodus-privacy.eu.org/en/) - Helps check permissions and trackers of Android apps, providing insights into the privacy aspects of different applications.
+- [Don't Kill My App](https://dontkillmyapp.com/) - A website advocating against aggressive app background process limitations on Android, which can negatively impact app performance.
+- [Mobile X Files](https://mobilexfiles.com/) - Smartphones' secret codes and other hidden functions.
+- [MobileRead Wiki](https://wiki.mobileread.com/wiki/Main_Page) - A comprehensive resource for eReaders, eBooks, and related technologies, providing guides, FAQs, and tutorials for users of various mobile reading devices.
+
+### Game Development
+
+- [itch.io](https://itch.io/) - A platform that provides a simple way to find and share indie games online for free.
+- [System Requirements Lab](https://www.systemrequirementslab.com/cyri) - Analyzes your computer's specifications in seconds, providing information on whether your system meets the requirements for various games.
+- [Kenney](https://kenney.nl/) - Platform offering free game assets, graphics, and game development resources.
+- [Flash Games Archive](https://flasharch.com/en) - Archive of Flash games, preserving these classic games for future enjoyment.
+- [OpenGameArt](https://opengameart.org/) - A platform offering free-to-use game assets, including 2D and 3D art, sound effects, and music for developers and game creators.
+- [Nexus Mods](https://www.nexusmods.com/) - One of the largest online communities for game modifications, offering a vast collection of mods for popular video games to enhance gameplay, add content, or personalize experiences.
+
+#### Game Theory
+
+- [Ncase](https://ncase.me/) - Game Theory explanations with simple games.
+- [Alberta Games Research](https://webdocs.cs.ualberta.ca/~games/) - A site from the University of Alberta offering resources and research related to game theory, computational models, and games as a computational study.
+- [Combinatorics.org](https://www.combinatorics.org/) - A. S. Fraenkel's bibliography of combinatorial game theory literature.
+- [Geometry and Graph Theory](https://ics.uci.edu/~eppstein/cgt/) - A resource on Combinatorial Game Theory, featuring explanations, examples, and research on algorithms for combinatorial problems.
+
+#### Games
+
+- [Bento Blocks Game](https://www.bentoblocksgame.com/) - Arrange ingredients in the bento box
+
+##### Pokemon
+
+- [Pokemon Database](https://pokemondb.net/) - A comprehensive Pokémon database with news and updates.
+- [Serebii](https://serebii.net/) - Offers various news, features, archives, and explanations about Pokémon.
+
+##### Chess
+
+- [The Chess Website](https://www.thechesswebsite.com/) - Learn, Practice, and Play Chess.
+- [Lichess](https://en.lichess.org/) - Free/libre, open-source chess server powered by volunteers and donations.
+- [Chess.com](https://www.chess.com/) - Online platform for online chess.
+
+### Embeddings
+
+- [FPGA4Fun](https://www.fpga4fun.com/) - Educational resources and tutorials focused on FPGA (Field-Programmable Gate Array) technology, providing practical guides for both beginners and advanced users.
+- [Wokwi](https://wokwi.com/) - Online ESP32, STM32, Arduino simulator.
+- [x86 Instruction Set Reference](https://c9x.me/x86/) - A mirror of the "Into the Void" reference for the x86 instruction set, providing a detailed guide to assembly language and processor instructions for x86 architecture.
+- [Analog Devices Wiki](https://wiki.analog.com/) - Knowledge base with technical documentation, tutorials, and resources on analog and mixed-signal devices, aimed at engineers and developers.
+- [IEEE-754 Floating Point Converter](https://www.h-schmidt.net/FloatConverter/IEEE754.html) - Tool to convert between the decimal representation of a number and the binary format used by modern CPUs, based on IEEE-754 standard.
+- [Guide to x86 Assembly](https://www.cs.virginia.edu/~evans/cs216/guides/x86.html) - Guide to x86 Assembly by University of Virginia Computer Science
+
+### Linux
+
+- [Linux Journey](https://linuxjourney.com/) - Platform for learning Linux.
+- [Run Linux in Your Browser](https://bellard.org/jslinux/) - Run Linux or other operating systems in your browser.
+- [OS Directory](https://os.directory/) - Platform that emulates a Linux distribution in your web browser.
+- [DistroWatch](https://distrowatch.com/) - Resource for Linux and BSD distributions, providing news, reviews, and comparisons to help users find and install the right operating system.
+- [SS64](https://ss64.com/) - Reference guide containing syntax and examples for the most prevalent computing commands, covering databases and operating systems.
+- [SS64 Bash Keyboard Shortcuts](https://ss64.com/bash/syntax-keyboard.html) - Reference guide for bash keyboard shortcuts.
+- [Command Line for Beginners](https://ubuntu.com/tutorials/command-line-for-beginners#1-overview) - Overview of the Linux command line for beginners.
+- [Linux Journey](https://linuxjourney.com/) - An educational website offering free, interactive lessons on Linux, covering everything from basic commands to advanced system administration.
+- [ExplainShell](https://explainshell.com/) - A tool for explaining Linux shell commands, providing detailed breakdowns of command syntax and function.
+- [LibreHunt](https://librehunt.org/) - Aid you on your Linux Distro (and potentially, Libre) hunt. Answer easy questions to get recommendations on which Linux distribution that meets your needs based on those responses.
+
+### Vim
+
+- [Vim Cheat Sheet](https://vim.rtorr.com/) - Vim cheat sheet.
+- [Learn Vim](https://learnvim.irian.to/) - A resource to learn Vim, the smart way.
+- [Vim Awesome](https://vimawesome.com/) - Search through listed Vim plugins
+- [Vim Adventures](https://vim-adventures.com/) - An interactive game designed to teach users the fundamentals of the Vim text editor through engaging puzzles and challenges.
+- [Vimified](https://www.vimified.com/) - Platform for learning and practicing Vim, a free and open-source, screen-based text editor program.
+
+### Git
+
+- [Git - The Simple Guide](https://rogerdudler.github.io/git-guide/) - A straightforward guide for getting started with Git.
+- [Git Sheet](https://gitsheet.wtf) - A quick reference guide for common Git commands.
+- [MiXLab on Google Colab](https://colab.research.google.com/github/shirooo39/MiXLab/blob/master/MiXLab.ipynb#scrollTo=e-0yDs4C0HkB) - A mixture of Google Colab notebooks compiled from GitHub.
+- [Learn Git Branching](https://learngitbranching.js.org/) - Interactive tool to learn Git branching through simulation of a git repository.
+
+### GitHub
+
+- [GitStalk](https://gitstalk.netlify.app/) - Platform to discover what individuals are working on in the GitHub community.
+- [GitExplorer](https://gitexplorer.com/) - Tool to find the right Git commands without searching through the web.
+- [GitStats](https://gitstats.me/) - Open-source GitHub contribution analyzer that provides insights into your GitHub activity.
+- [Gitcoin](https://gitcoin.co/) - Platform where individuals can get paid for contributing to open-source software in various programming languages and domains.
+- [Oh Shit, Git!](https://ohshitgit.com/) - Resource providing solutions for common Git mistakes and how to recover from them.
+- [GitHub Trending Archive](https://github.motakasoft.com/trending/) - Archive of trending repositories on GitHub, allowing users to explore popular projects and programming trends over time.
+- [Map of GitHub](https://anvaka.github.io/map-of-github/) - Visual representation of the GitHub repository network.
+
+### IDEs
+
+- [OneLang IDE](https://ide.onelang.io/) - Online tool for converting code from one programming language to another.
+- [Theia IDE](https://theia-ide.org/) - Flexible and extensible cloud and desktop IDE platform, enabling efficient development and delivery of IDEs and tools using modern web technologies.
+- [VSCode Themes](https://vscodethemes.com/) - A platform offering a wide variety of themes for Visual Studio Code, allowing users to personalize the look and feel of their coding environment with different color schemes and styles.
+
+## Privacy
+
+- [ToS;DR](https://tosdr.org/) - Terms of Service; Didn't Read (short: ToS;DR).
+- [Nothing Private](https://www.nothingprivate.ml/) - Check why you are not anonymous when using private browsing mode or incognito mode. You can also read it [here](https://github.com/gautamkrishnar/nothing-private).
+- [TrustPage](https://trustpage.com/directory) - Find and compare security policies for thousands of companies to choose the right software and services based on security policies sourced from around the web.
+- [Arkenfox User.js](https://github.com/arkenfox/user.js/wiki/4.1-Extensions) - Privacy and security-related browser extensions.
+- [Cookiepedia](https://cookiepedia.co.uk/) - The largest database of pre-categorized cookies and online tracking technologies.
+- [Security Planner](https://securityplanner.consumerreports.org/) - Get customized recommendations to cut down on data collection and prevent hacking.
+- [MyWhisper](https://mywhisper.net/) - A text encryption tool based on AES cryptography.
+- [BeEncrypted](https://beencrypted.com/) - Resources to become more encrypted.
+- [Prism Break](https://prism-break.org/en/all/) - Private and safe alternatives to the most used apps and services.
+- [Reddit Piracy Megathread](https://www.reddit.com/r/piracy/wiki/megathread/tools) - A list of apps, tools, and web services.
+- [Ressources](https://gitlab.com/tzkuat/Ressources) - List of websites on different areas such as security, OSINT, etc.
+- [Privacy Tools List by CHEF-KOCH](https://chef-koch.bearblog.dev/privacy-tools-list-by-chef-koch/) - A comprehensive list of privacy tools.
+- [Privacy Analyzer](https://privacy.net/analyzer/#pre-load) - Analyze privacy settings for websites.
+- [Shut Up Trackers](https://shutuptrackers.com/) - Provides information for protecting your data security and privacy.
+- [EFF Surveillance Self-Defense](https://ssd.eff.org/) - Tips, tools, and how-tos for safer online communications.
+- [Router Passwords](https://www.routerpasswords.com/) - The most updated default router password repository on the internet.
+- [BugMeNot](https://bugmenot.com/) - Find and share logins for various websites.
+- [Security.org](https://www.security.org/security-score/) - Learn about your security score.
+- [LibreProjects](https://libreprojects.net/#favs=wikipedia,joindiaspora-com,nextcloud,openstreetmap,jamendo,plos) - A list of 118 open-source hosted web services.
+- [Privnote](https://privnote.com/) - Send notes that will self-destruct after being read.
+- [Dangerzone](https://dangerzone.rocks/) - Platform for converting potentially unsafe PDFs, Office documents, or images into safe, viewable formats.
+- [ExifTool](https://exiftool.org/) - Software for reading, writing, and editing metadata in image, audio, and video files.
+- [HideMyWeb](https://hidemyweb.wordpress.com/) - Tool to hide, blur, and highlight content on web pages.
+- [Browser.lol](https://browser.lol/) - Browse anonymously with a free virtual environment within your browser.
+- [OneTimeSecret](https://onetimesecret.com/) - Platform for sharing a password, secret message or private link securely with one-time links.
+- [MetaDefender](https://metadefender.opswat.com/) - Online tool for scanning and analyzing files for security threats, providing detailed reports on potential risks.
+- [FotoForensics](https://fotoforensics.com/) - Online tool for analyzing and verifying digital images, providing forensic tools to detect alterations and edits in photos.
+
+### Cryptography
+
+- [Cryptologie](https://www.cryptologie.net/) - A website covering various topics in cryptography.
+- [Invisible](https://mikebradley.me/invisible/index.html) - A tool that hides text in images and allows you to find hidden text.
+
+### GAFA Alternatives
+
+- [DeGoogle](https://degoogle.jmoore.dev/#mobile-applications-mobile-apps-installable-from-stores) - Huge list of alternatives to Google products. Privacy tips, tricks, and links.
+- [Degooglisons Internet](https://degooglisons-internet.org/en/) - Alternatives to FAANG.
+- [AccountKiller](https://www.accountkiller.com/en/home) - AccountKiller collects direct links and deleting instructions to make account termination easy.
+- [JustDeleteMe](https://backgroundchecks.org/justdeleteme/) - A directory of direct links to delete your account from web services.
+- [SmartTubeNext](https://github.com/yuliskov/SmartTubeNext) - Ad-free app for watching YouTube videos on Android TV boxes.
+- [Libredirect](https://libredirect.github.io/) - Web extension that redirects YouTube, Twitter, Instagram requests to alternative privacy-friendly frontends and backends.
+
+### Ad Blocker
+
+- [Adblock Tester](https://adblock-tester.com/) - Tool to check the effectiveness of your AdBlock extensions.
+- [12ft](https://12ft.io/) - Remove paywalls and gain access to articles.
+- [Incoggo](https://incoggo.com/) - Adblocker for paywalls.
+
+### Emails
+
+- [BurnerMail](https://burnermail.io/) - Protect your personal email address, control who can send you emails, and generate new burner addresses with one click.
+- [Kill the Newsletter](https://kill-the-newsletter.com/) - Transform email newsletters into Atom feeds for easier consumption.
+- [Dead Man's Switch](https://www.deadmansswitch.net/) - A service that sends your emails to your designated recipients if you don't interact with it within a specified timeframe.
+- [YAMM](https://yamm.com/) ($) - Mail merge for Gmail, allowing you to send mass emails with Gmail, ensuring delivery to the primary inbox. Track results in real-time directly from Google Sheets.
+
+#### Disposable Email
+
+- [Erine Email](https://erine.email/) - An anti-spam service for your existing email address.
+- [Maildrop](https://maildrop.cc/) - Use Maildrop when you don't want to give out your real email address.
+- [Mailsac](https://mailsac.com/) - Offers disposable email services for testing and development purposes.
+- [InboxKitten](https://inboxkitten.com/) - An open-source disposable email service.
+- [Guerrilla Mail](https://www.guerrillamail.com/inbox) - Allows you to compose emails and determine the domain, master passphrase, and password of your disposable email.
+- [EmailDrop](https://www.emaildrop.io/) - Enables you to create emails with custom or random domains in a highly minimalistic design.
+- [GetNada](https://getnada.com/) - Provides temporary email addresses.
+- [GetNotify](https://www.getnotify.com/) - A free email tracking service that notifies you when the emails you send are read.
+- [MXToolbox](https://mxtoolbox.com/) - Offers free DNS and email tools in a single place for streamlined troubleshooting.
+- [Postale](https://postale.io/) ($) - Allows you to create domain email addresses effortlessly in minutes.
+
+### Data Breach
+
+- [Have I Been Pwned](https://haveibeenpwned.com/) - Check if your email or phone is in a data breach.
+- [TinEye](https://tineye.com/) - Find where images appear online.
+- [IPLeak](https://ipleak.net/) - See the kind of information that all the sites you visit can see and collect about you.
+- [Cover Your Tracks](https://coveryourtracks.eff.org/) - Test your browser to see how well you are protected from tracking and fingerprinting.
+- [Am I FLoCed](https://amifloced.org/) - Check if Google is testing FLoC on your Chrome browser.
+
+### Search
+
+- [Startpage](https://www.startpage.com/) - Get privacy protection across the web.
+- [Neeva](https://neeva.com/) - Ad-free, private search engine with a subscription model.
+- [AndiSearch](https://andisearch.com/) - Ad-free and anonymous search engine.
+- [Plex Page](https://plex.page/) - Search summarization tool.
+- [Marginalia Search](https://search.marginalia.nu/) - Independent DIY search engine focusing on non-commercial content.
+- [Unlisted Videos](https://unlistedvideos.com/) - For submitting, searching for, and watching unlisted YouTube videos. No registration required.
+- [Filmot](https://filmot.com/) - Search within YouTube subtitles.
+- [XN--1-ZFA](https://xn--1-zfa.com/) - Advanced search for Google, DuckDuckGo, Twitter, YouTube, Reddit.
+- [Seekr](https://www.seekr.com/) - Search engine that utilizes AI to analyze and score the quality of content, starting with news articles.
+- [Million Short](https://millionshort.com/) - Discover content beyond the first million search results.
+
+### Internet
+
+- [Internet Live Stats](https://www.internetlivestats.com/) - Provides real-time statistics about the internet, including the number of websites, emails, and more.
+- [Internet Map](https://internet-map.net/) - An interactive map that visually represents the internet, showing the relationships between various websites.
+- [Test IPv6](https://test-ipv6.com/) - Allows you to test your IPv6 connectivity and provides information about your network setup.
+- [TLS 1.2 Explained](https://tls12.xargs.org/) - Provides a detailed explanation of every byte in a TLS connection.
+- [CIDR.xyz](https://cidr.xyz/) - An interactive IP address and CIDR range visualizer.
+- [I Can Haz IP](https://icanhazip.com/) - Displays only your IP address at the top of the page.
+- [IP Location](https://iplocation.io/) - Provides free location tracking of an entered IP address, including city, country, latitude, and longitude.
+- [Ifconfig.co](https://ifconfig.co/) - Helps you find your own IP address and provides information about it.
+- [IPinfo.io](https://ipinfo.io/) - Offers accurate IP address data for various use cases.
+- [Visual Subnet Calculator](https://www.davidc.net/sites/default/subnets/subnets.html) - A visual subnet calculator to help with IP address and subnet calculations.
+- [Ping Test](https://www.meter.net/ping-test/) - Online tool to measure network latency by sending test packets (pings) to a specified server, providing insights into connection stability and speed.
+- [LibreSpeed](https://librespeed.org/) - Open-source internet speed test tool, offering accurate measurements of download, upload, and latency without requiring additional software installations.
+
+#### DNS
+
+- [How DNS Works](https://howdns.works/) - Offers a colorful explanation of how DNS works with the help of comics.
+- [DNS Checker](https://dnschecker.org/) - Provides a free DNS lookup service to check Domain Name System records against a selected list of DNS servers worldwide.
+- [AdGuard DNS Providers](https://kb.adguard.com/en/general/dns-providers) - A list of DNS providers that you can configure to use instead of the default provided by your router or ISP.
+- [DNS Speed Test](https://dnsspeedtest.online/) - Fast DNS server speed test tool, allowing users to find the most optimal DNS server for faster internet browsing with no installation required.
+
+### URL
+
+- [URL Tools](https://shrtco.de/tools/) - Various tools for URLs.
+- [OneLink](https://www.onelink.to/) - Platform for creating links and QR codes for your apps.
+- [QR Code Generator](https://freecodetools.org/qr-code-generator/) - Tool for generating QR codes.
+- [AppOpener](https://appopener.com/) - Create smart links to open desired apps from URLs without login.
+- [Who Is Hosting Any Domain](https://digital.com/best-web-hosting/who-is/) - Find out who is hosting any domain, including web host, IP address, name servers, and more.
+- [Webhook.Site](https://webhook.site/) - Platform to inspect, test, and automate any incoming HTTP request or email.
+- [GoQR.Me](https://goqr.me/) - Generator for high-resolution QR codes suitable for print.
+- [Open Graph Generator](https://freecodetools.org/ogp/) - Tool for generating Open Graph images.
+
+#### URL Shortener
+
+- [Rebrandly](https://www.rebrandly.com/) - A link management platform to brand, track, and share short URLs using a custom domain name.
+- [Bit.do](https://bit.do/) - Provides real-time traffic statistics for your links for free.
+- [s.id](https://home.s.id/) - Link shortener and microsite builder.
+- [TinyURL](https://tinyurl.com/app) - Offers optional short link endings.
+- [Tiny.cc](https://tiny.cc/) - Offers optional short link endings.
+- [Bitly](https://bitly.com/) - Web/mobile link management and campaign management analytics as well as branded links.
+- [iplogger.org](https://iplogger.org/) - URL shortener with advanced analytics for the traffic through your links, visitors on your online store, blog, or website.
+- [cutr.ml](https://cutr.ml/) - URL shortener.
+- [is.gd](https://is.gd/) - URL shortener.
+- [gg.gg](https://gg.gg/) - URL shortener.
+- [shrunken.com](https://www.shrunken.com/) - URL shortener.
+
+### Password Generation
+
+- [Everything About Passwords and Internet Security](https://www.healthypasswords.com/index-2.html) - Comprehensive information on passwords and internet security.
+- [Random Password Generator](https://random-password-gen.web.app/) - Generate random and secure passwords.
+- [How Secure Is My Password?](https://www.security.org/how-secure-is-my-password/) - Check the security strength of your password. Entries are secure and not stored or shared.
+- [Password Generator](https://freecodetools.org/password-generator/) - Generate secure passwords easily.
+
+## Softwares
+
+- [OlderGeeks](https://oldergeeks.com/) - Ad-free software download site supported by donations, providing a hassle-free experience.
+- [AlternativeTo](https://alternativeto.net/) - Discover the best alternatives to popular software based on user recommendations.
+- [Open Source Alternative](https://www.opensourcealternative.to/) - Platform providing open-source alternatives to proprietary software.
+- [Dark Mode List](https://darkmodelist.com/) - List of 300 apps that support dark mode.
+- [LocalStack](https://localstack.cloud/) - Develop and test cloud and serverless apps offline.
+- [Markwhen](https://markwhen.com/) - Text-to-timeline tool converting markdown-ish text into a cascading timeline.
+- [Asciinema](https://asciinema.org/) - Record and share your terminal sessions with a purely text-based approach.
+- [Apache Guacamole](https://guacamole.apache.org/) - Clientless remote desktop gateway supporting protocols like VNC, RDP, and SSH.
+- [DockerSwarm.rocks](https://dockerswarm.rocks/) - Deploy your application stacks to production in a distributed cluster using Docker Compose files.
+- [EasyCron](https://www.easycron.com/) - Online cron job service (Paid).
+- [CDecl](https://cdecl.org/) - Translate C gibberish to English, helping you understand complex C declarations.
+- [NirSoft](https://www.nirsoft.net/) - Collection of small utilities for Windows, including system tools, password recovery tools, and more.
+- [Ninite](https://ninite.com/) - Install and update multiple programs at once without toolbars or unnecessary clicks.
+- [ReadWok](https://app.readwok.com/lib) - Online text reader with a progressive viewing mode, allowing paragraph-by-paragraph reading and editing.
+- [BitwiseCMD](https://bitwisecmd.com/) - Online bitwise operations and conversions.
+- [Commands.dev](https://www.commands.dev/?ref=producthunt) - Searchable, templated catalog of popular terminal commands curated from across the internet.
+- [SourceForge](https://sourceforge.net/) - Web-based service that allows you to compare, download and develop open source and business software.
+
+### Snippets
+
+- [CodeClippet](https://codeclippet.com/) - Platform for sharing code snippets within a community-focused environment.
+- [Kod.so](https://kod.so/) - Platform for creating visual snippets, with the ability to download and share them.
+- [CodePNG](https://www.codepng.app/) - Tool for creating pictures from source code by converting code into images.
+- [CodeMyUI](https://codemyui.com/) - Website providing web design and UI inspiration with curated code snippets.
+- [30 Seconds of Code](https://www.30secondsofcode.org/list/p/1) - Curated collection of short code snippets for various development needs.
+- [W3Schools HowTo](https://www.w3schools.com/howto/default.asp) - W3Schools section offering code snippets for HTML, CSS, and JavaScript.
+- [Snipplr](https://snipplr.com/) - Platform for keeping frequently used code snippets in one accessible place, allowing users to share and discover code snippets.
+- [LittleSnippets](https://littlesnippets.net/) - Platform for sharing and discovering small code snippets.
+- [CodeToGo](https://codetogo.io/) - Resource to find up-to-date snippets for JavaScript and React use cases.
+- [TweetSnippet](https://tweetsnippet.com/) - Curated list of tips and tricks from Twitter, presented in code snippet form.
+- [CSS-Tricks Snippets](https://css-tricks.com/snippets/) - Collection of CSS snippets covering various design and layout techniques.
+- [Crontab Guru](https://crontab.guru/) - Quick and simple editor for cron schedule expressions, providing human-readable explanations.
+- [Crontab Generator](https://crontab-generator.org/) - Online tool to generate cron schedule expressions with a user-friendly interface.
+- [Carbon](https://carbon.now.sh/) - Web-based tool for creating and sharing beautiful images of source code snippets with syntax highlighting.
+
+### Linters
+
+- [FromLatest.io](https://www.fromlatest.io/#/) - Dockerfile linter for checking the syntax and best practices in Dockerfiles.
+- [YAMLlint](https://www.yamllint.com/) - Online tool to check the validity of YAML code and provide a clean UTF-8 version optimized for Ruby.
+- [K8sYaml](https://k8syaml.com/) - Kubernetes YAML Generator for creating Kubernetes configuration files.
+- [Puppet Validator](https://validate.puppet.com/) - Tool to check the validity of Puppet code syntax without compiling or enforcing a catalog.
+- [ShellCheck](https://www.shellcheck.net/) - Online platform for finding bugs in shell scripts by analyzing and providing suggestions for improvement.
+- [Beautifier.io](https://beautifier.io/) - Online tool to beautify, unpack, or deobfuscate JavaScript and HTML, and make JSON/JSONP readable.
+- [JSONLint](https://jsonlint.com/) - Validator and reformatter for JSON, providing tidying and validation for messy JSON code.
+- [Algorithm Visualizer](https://algorithm-visualizer.org/) - Interactive platform that visualizes algorithms from code to help understand their execution.
+- [CodeBeautify](https://codebeautify.org/) - Online platform offering code formatting tools, including JSON beautifier, XML viewer, hex converters, and more.
+- [ExplainShell](https://explainshell.com/) - Tool to explain command-line commands by displaying the help text for each argument.
+- [ShowTheDocs](https://showthedocs.com/) - Documentation browser that finds relevant docs for your code, making it easier to explore and understand.
+- [Mango - Specification Interpretation](https://mango-slra1-ckwssph7iq-ue.a.run.app/readme) - Technique to interpret specifications and automatically identify defects such as logical contradictions, over-complexity, and inconsistency of entity names.
+- [Code Minifier](https://freecodetools.org/minifier/) - Online tool for minifying code to reduce file size and improve load times.
+- [Markdown Preview](https://freecodetools.org/markdown-preview/) - Online tool for previewing and formatting Markdown text.
+- [Code Beautifier](https://freecodetools.org/beautifier/) - Online tool for beautifying and formatting code for improved readability.
+- [CodePad](https://codepad.org/) - Online compiler/interpreter and collaboration tool, allowing users to run and share code snippets with a short URL.
+- [JSON Formatter](https://jsonformatter.org/json-parser) - Online JSON parser and formatter.
+- [SQL Formatter](https://formatjsononline.com/sql-formatter) - Free Online SQL Formatter & Beautifier.
+
+### Testing
+
+- [OWASP Fuzzing Project](https://owasp.org/www-community/Fuzzing) - The official page for the OWASP Fuzzing Project, which aims to improve the overall state of fuzzing tools, techniques, and processes.
+- [Awesome Fuzzing](https://github.com/secfigo/Awesome-Fuzzing) - A curated list of fuzzing resources, including tools, tutorials, research papers, and more.
+
+### Regex
+
+- [Regex Cheat Sheet](https://dev.to/emmabostian/regex-cheat-sheet-2j2a) - A helpful guide for regular expressions.
+- [RegExr](https://regexr.com/) - An online tool to learn, build, and test Regular Expressions (RegEx/RegExp).
+- [Regulex](https://jex.im/regulex/) - JavaScript Regular Expression Visualizer for understanding and visualizing regular expressions.
+- [Regex101](https://regex101.com/) - An online regex tester and debugger.
+- [Debuggex](https://www.debuggex.com/) - A visual regex tester that allows you to understand how your regular expression works.
+- [UI Bakery Regex Library](https://uibakery.io/regex-library/) - Collection of regular expressions for UI design.
+- [Pyrexp](https://pythonium.net/regex) - An online visual regex tester for Python.
+
+### No-Code
+
+- [No Code List](https://nocodelist.co/) - Browse categories to discover over 300 no-code tools.
+- [No-Code Things](https://www.spacebarcounter.net/no-code-tools) - A collection of no-code tools.
+
+#### Licensing
+
+- [ChooseALicense - Appendix](https://choosealicense.com/appendix/) - Additional information and resources related to open source licenses.
+- [GitHub Docs - Licensing a Repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) - GitHub's documentation on licensing a repository.
+- [Public License Selector](https://ufal.github.io/public-license-selector/) - Helps you choose an open source license based on your preferences.
+- [Creative Commons License Chooser](https://creativecommons.org/choose/) - Choose a Creative Commons license that suits your content sharing preferences.
+- [License Buttons](https://licensebuttons.net/) - Get buttons for your website that indicate the license terms of your content.
+- [Shields.io](https://shields.io/) - Create custom badges (shields) for your GitHub repositories, providing information like license, version, and more.
+
+## Programming Languages
+
+- [EbookFoundation-Free-Programming-Books](https://github.com/EbookFoundation/free-programming-books/blob/main/books/free-programming-books-langs.md) - Free and open source programming books
+- [Codecademy Catalog](https://www.codecademy.com/catalog) - Platform offering a catalog of courses for learning various programming languages and technologies.
+- [Learn X in Y Minutes](https://learnxinyminutes.com/) - Resource providing a quick whirlwind tour of various programming languages.
+- [eComputerNotes](https://ecomputernotes.com/) - Learning resource for online education, covering a wide range of computer science and programming topics.
+- [Libraries.io](https://libraries.io/) - Platform to discover new open-source packages, modules, and frameworks, and keep track of dependencies.
+- [LearnByExample](https://www.learnbyexample.org/) - Platform to learn Python, SQL, and R languages with examples and practical explanations.
+- [PythonTutor](https://pythontutor.com/) - Tool that helps users learn Python, JavaScript, C, C++, and Java programming by visualizing code execution step by step.
+- [Classic Papers in Programming Languages and Logic](https://www.cs.cmu.edu/~crary/819-f09/) - Collection of seminal academic papers on programming languages and logic, curated by Carnegie Mellon University.
+- [RubyGems Guides](https://guides.rubygems.org/) - Learn how RubyGems works and how to make your own
+
+### Haskell
+
+- [Learn You a Haskell for Great Good!](https://learnyouahaskell.github.io/chapters.html) - Online book version of "Learn You a Haskell" by by Miran Lipovača.
+- [Real World Haskell](https://book.realworldhaskell.org/read/) - Online book version of "Real World Haskell" by Bryan O'Sullivan, Don Stewart, and John Goerzen.
+- [CIS 194 - Introduction to Haskell (Spring 2013)](https://www.seas.upenn.edu/~cis1940/spring13/lectures.html) - Lecture materials and resources on Haskell programming.
+- [GitHub - Programming in Haskell](https://github.com/topics/programming-in-haskell) - Collection of Haskell-related repositories and projects on GitHub.
+
+### Python
+
+- [Python Documentation](https://docs.python.org/3/) - Official documentation for the Python programming language.
+- [Python Wiki](https://wiki.python.org/moin/FrontPage) - Collaborative platform providing information and resources related to Python.
+- [Awesome Python](https://awesome-python.com/) - Curated list of awesome Python frameworks, libraries, software, and resources.
+- [Project Python](https://projectpython.net/) - Platform offering Python tutorials and resources for learning and development.
+- [Learn Python](https://www.learnpython.org/) - Interactive platform providing tutorials and exercises to learn Python programming.
+- [CSCircles](https://cscircles.cemc.uwaterloo.ca/) - Online platform offering interactive Python exercises and resources, developed by the University of Waterloo.
+- [PythonBasics](https://pythonbasics.org/) - Website providing resources and tutorials for learning Python basics.
+- [Majyori](https://www.majyori.com/) - Platform offering Python tutorials and resources for learners of all levels.
+- [PyFormat](https://pyformat.info/) - Website comparing Python formatting styles with examples from different versions.
+- [Learn by Example - Python Resources](https://learnbyexample.github.io/py_resources/) - Collection of Python resources and tutorials for various topics.
+- [Data to Fish](https://datatofish.com/python-tutorials/) - Platform offering clear Python tutorials covering topics such as machine learning, databases, pandas, GUI, and more.
+- [Notion Programming Course](https://www.notion.so/Programming-Course-4d4331de1a0c4ae894133cb1ca1e9315) - Self-study course for learning to build basic web applications in Django, hosted on Notion.
+
+### C++
+
+[LearnCpp.com](https://www.learncpp.com/) - A comprehensive resource for learning C++ programming.
+
+## Coding Practice / Competitive Programming
+
+- [LeetCode](https://leetcode.com/) - Platform for practicing coding problems with a focus on algorithmic challenges.
+- [NeetCode](https://neetcode.io/) - Coding practice website designed to enhance your skills through real-world projects and collaborative coding.
+- [HackerRank](https://www.hackerrank.com/dashboard) - Coding platform offering challenges in various domains, from algorithms to artificial intelligence.
+- [CodeWars](https://www.codewars.com/) - Community-driven platform providing coding challenges with a focus on improving through peer-reviewed solutions.
+- [Project Euler](https://projecteuler.net/about) - Mathematics-oriented coding platform, featuring challenging problems to encourage problem-solving through programming.
+- [Kattis Guide](https://unh-cpc.github.io/kattisguide.html) - A guide to solving competitive programming problems using the Kattis platform, providing tips, problem-solving strategies, and resources for participants.
+- [Kaggle](https://www.kaggle.com/) - Data science platform that hosts competitions, datasets, and notebooks, fostering collaboration and innovation in the field.
+- [Replit](https://replit.com/) - Online coding environment facilitating collaborative coding, with features like live sharing and a wide range of supported languages.
+- [AlgoLeague](https://www.algoleague.com/) - Competitive programming platform for practicing algorithmic problem-solving.
+- [Codeforces](https://codeforces.com/) - Online competitive programming platform offering contests and a vast problem set, attracting a diverse international user base.
+- [AtCoder](https://atcoder.jp/) - Japanese competitive programming platform hosting contests and exercises to enhance algorithmic skills.
+- [InterviewBit](https://www.interviewbit.com/coding-interview-questions/) - Platform offering coding interview questions and challenges to help prepare for technical interviews.
+- [Advent of Code](https://adventofcode.com/) - Advent calendar of small programming puzzles suitable for various skill sets and levels, solvable in any programming language.
+- [CList](https://clist.by/) - List of competitions from various programming websites, providing a centralized resource for upcoming contests.
+- [Codeply](https://www.codeply.com/) - Free online editor featuring dozens of frameworks, starter templates, and over 50,000 code snippets.
+- [URI Online Judge](https://www.urionlinejudge.com.br/judge/en/login) - Platform for training algorithms and programming challenges to enhance programming skills.
+- [Rosalind](https://rosalind.info/problems/locations/) - Platform for learning bioinformatics and programming through problem-solving.
+- [Kattis](https://open.kattis.com/) - Platform with hundreds of programming problems to solve, helping users practice and improve their coding skills.
+- [Exercism](https://exercism.org/tracks) - Platform for developing fluency in 67 programming languages through a unique blend of learning, practice, and mentoring, offered for free.
+- [Codility](https://codility.com/programmers/challenges) - Platform offering coding challenges to assess and improve algorithmic and problem-solving skills.
+- [r/dailyprogrammer](https://www.reddit.com/r/dailyprogrammer/) - Subreddit on Reddit featuring daily programming challenges and discussions for coding enthusiasts.
+- [Daily Coding Problem](https://www.dailycodingproblem.com/) - Service that sends daily coding challenges to subscribers to improve coding and problem-solving skills.
+- [Coderbyte](https://coderbyte.com/) - Platform with coding challenges and interview preparation resources to enhance programming skills.
+- [CodinGame](https://www.codingame.com/start) - Online platform gamifying coding challenges, making learning and practicing programming more engaging.
+- [A2OJ](https://a2oj.netlify.app/) - Competitive programming resource providing a structured ladder system to improve problem-solving skills, categorized by difficulty levels and topics.
+- [CodeChef](https://www.codechef.com/) - Competitive programming website with regular contests and a large problem archive, catering to a global coding community.
+- [USACO](http://usaco.org/index.php?page=contests) - USA Computing Olympiad platform, providing programming contests to encourage and identify talented young programmers in the United States.
+- [USACO Guide](https://usaco.guide/) - Comprehensive, free resource collection guiding users from Bronze to Platinum levels and beyond in competitive programming.
+- [JoinCPI](https://joincpi.org/) - Platform dedicated to promoting competitive programming among students through resources, classes, outreach, and contests.
+- [CP-Algorithms](https://cp-algorithms.com/) - Website providing a detailed guide to algorithms specifically tailored for competitive programming, offering in-depth explanations and examples.
+- [CSS Battle](https://cssbattle.dev/) - Platform challenging users to use CSS skills to replicate targets with the smallest possible code.
+- [JavaScript Quiz](https://javascriptquiz.com/) - Website offering quizzes focused on testing and enhancing knowledge of JavaScript programming language.
+- [Elevator Saga](https://play.elevatorsaga.com/) - Game for learning and practicing JavaScript.
+- [Deep ML](https://www.deep-ml.com/) - Website offering ML Code Challenges.
+- [Hack The Box](https://www.hackthebox.com/) - An online platform for hacking training, offering virtual environments and challenges to help individuals and organizations develop cybersecurity skills.
+
+### Capture the Flag
+
+- [CTF101](https://ctf101.org/) - Platform providing educational resources for those new to Capture The Flag competitions.
+- [CTFtime](https://ctftime.org/) - Archive of Capture The Flag events, teams, and timelines.
+- [Google CTF on GitHub](https://github.com/google/google-ctf) - Google's Capture The Flag competition resources available on GitHub.
+- [Meusec CTF Resources](https://www.meusec.com/ctf/capture-the-flags-in-cybersecurity/) - Meusec's collection of Capture The Flag (CTF) resources in cybersecurity.
+- [Trail of Bits - CTF Guide](https://trailofbits.github.io/ctf/) - Guide by Trail of Bits providing insights and tips for participating in Capture The Flag competitions.
+
+### Projects
+
+- [Projects-Solutions on GitHub](https://github.com/karan/Projects-Solutions) - GitHub repository providing project-based coding challenges for learning programming through practical applications.
+- [Build Your Own X](https://github.com/codecrafters-io/build-your-own-x#build-your-own-neural-network) - GitHub repository providing guides on building your favorite technologies from scratch.
+- [Arduino Project Hub](https://projecthub.arduino.cc/) - Hub for sharing and discovering Arduino projects.
+- [Projects in Networking](https://projectsinnetworking.com/) - Resource for networking projects, network security projects, cyber security case studies, and source code for students, graduates, and professionals in the computer networking and security domain.
+
+### Open Source
+
+- [LibHunt](https://www.libhunt.com/) - Platform for discovering trending open-source projects and their alternatives.
+- [Awesome Open Source](https://awesomeopensource.com/) - A platform to find open source projects by searching, browsing, and combining topics across various categories and projects.
+- [Open Source Libs](https://opensourcelibs.com/) - A massive collection of the world's best open source software.
+- [CodeTriage](https://www.codetriage.com/) - A list of open source repositories' issues that you can contribute to, with the option to receive issues via email if you sign up.
+- [GitLab Explore](https://gitlab.com/explore/projects/starred/) - Explore projects on GitLab.
+- [Open Source Guide](https://opensource.guide/) - Guide providing resources for launching and growing open source projects.
+- [The Architecture of Open Source Applications](https://aosabook.org/en/index.html) - Book series about the design and architecture of various open-source software projects.
+- [OSS Gallery](https://oss.gallery/) - A crowdsourced collection of the best open-source projects across the internet, providing an easy way to discover and explore top software repositories and tools.
+
+### Hackathons
+
+- [DEVPOST Hackathons](https://devpost.com/hackathons) - Find online and in-person hackathons.
+- [GitHub Education Events](https://education.github.com/events) - Find members of the community at hackathons, conferences, and events near you.
+- [Hackathons by Hack Club](https://hackathons.hackclub.com/) - Curated list of high school hackathons, featuring 699 events in 27 states and 18 countries.
+- [Cerebral Valley AI Events](https://events.cerebralvalley.ai/) - Provides information on upcoming AI-related events, hackathons, and co-working opportunities.
+
+## Cheat Sheets
+
+- [DevHints](https://devhints.io) - Collection of cheatsheets for various programming languages and tools.
+- [Cheatography](https://cheatography.com/) - Platform providing user-generated cheat sheets on various topics.
+- [Sound of Sorting Algorithm Cheat Sheet](https://panthema.net/2013/sound-of-sorting/SoS-CheatSheet.pdf) - Cheat sheet related to the "Sound of Sorting" algorithm visualization project.
+- [SANS Cheat Sheets](https://www.sans.org/blog/the-ultimate-list-of-sans-cheat-sheets/) - Ultimate list of SANS cheat sheets covering general IT security topics.
+- [Codecademy Cheatsheets](https://www.codecademy.com/resources/cheatsheets/all) - Collection of cheat sheets for various programming languages and concepts.
+- [Awesome Cheatsheets](https://lecoupa.github.io/awesome-cheatsheets/) - Curated list of awesome cheatsheets covering a wide range of programming languages, tools, and topics.
+- [OverAPI](https://overapi.com/) - Platform providing centralized access to cheatsheets and quick references for various programming languages and frameworks.
+- [Nota Language](https://nota-lang.org/) - Document language designed for the browser, offering a simplified syntax for creating web-based documents.
+- [Cheat-Sheets.org](https://www.cheat-sheets.org/) - Compilation of cheat sheets, round-ups, quick reference cards, guides, and sheets covering various topics.
+
+### Python Cheat Sheet
+
+- [Speedsheet](https://speedsheet.io/) - An interactive Python cheatsheet for faster and better coding.
+- [Python Cheatsheet](https://www.pythoncheatsheet.org/) - A cheatsheet based on the book "Automate the Boring Stuff with Python" and various other sources.
+- [Zero to Mastery Python Cheat Sheet](https://zerotomastery.io/cheatsheets/python-cheat-sheet/) - Python cheat sheet provided by Zero to Mastery.
+
+### Front-end Cheat Sheet
+
+- [Can I use](https://caniuse.com/) - Provides up-to-date browser support tables for front-end web technologies on desktop and mobile browsers.
+- [Easings](https://easings.net/en) - Helps you choose the right easing function for animations.
+- [WebCode.tools](https://webcode.tools/) - Code generators to assist with front-end web projects.
+- [MarkSheet](https://marksheet.io/) - Offers a free HTML and CSS tutorial.
+- [Xul.fr](https://www.xul.fr/en/) - A tutorial and index for CSS, HTML, and JavaScript.
+- [Emmet Cheat Sheet](https://docs.emmet.io/cheat-sheet/) - A cheat sheet for Emmet, a toolkit for web developers to write HTML and CSS code faster.
+
+#### HTML Cheat Sheet
+
+- [HTML Cheat Sheet](https://htmlcheatsheet.com) - Comprehensive HTML cheat sheet covering various elements and attributes.
+- [HTML5 Doctor Element Index](https://html5doctor.com/element-index/) - Quick reference for elements that are new or redefined in HTML5.
+- [HTML5 Canvas Cheat Sheet](https://simon.html5.org/dump/html5-canvas-cheat-sheet.html) - Cheat sheet for HTML5 Canvas, providing a quick reference for its properties and methods.
+- [HTML Vocabulary](https://apps.workflower.fi/vocabs/html/en#children) - Resource providing an HTML vocabulary, categorizing elements and their relationships.
+- [HTML Reference](https://htmlreference.io/) - Free guide to HTML, featuring all HTML elements and attributes with detailed explanations.
+
+#### CSS Cheat Sheet
+
+- [CSS Reference](https://cssreference.io) - Comprehensive reference guide for CSS properties and selectors.
+- [Grid Malven](https://grid.malven.co) - Interactive guide for CSS Grid layout.
+- [Flexbox Malven](https://flexbox.malven.co/) - Interactive guide for CSS Flexbox layout.
+- [Justin Aguilar Animations](https://www.justinaguilar.com/animations/) - Collection of CSS animations with live previews.
+- [CSS Grid Cheat Sheet](https://alialaa.github.io/css-grid-cheat-sheet/) - Visual cheat sheet for CSS Grid layout.
+- [Adam Marsden CSS Cheat Sheet](https://adam-marsden.co.uk/css-cheat-sheet) - CSS cheat sheet with concise explanations and examples.
+- [Responsive Web Design Cheat Sheet](https://uxpin.s3.amazonaws.com/responsive_web_design_cheatsheet.pdf) - PDF cheat sheet for responsive web design principles.
+- [Media Queries Cheat Sheet](https://mac-blog.org.ua/css-3-media-queries-cheat-sheet) - Cheat sheet for CSS3 media queries.
+- [Bootsnipp](https://bootsnipp.com/) - Platform providing design elements, playground, and code snippets for Bootstrap HTML/CSS/JS framework.
+- [Bootstrap Cheatsheet](https://hackerthemes.com/bootstrap-cheatsheet/) - Visual cheat sheet for the Bootstrap framework.
+- [HackerThemes](https://hackerthemes.com/) - UI/UX resources based on the Bootstrap framework.
+
+## Building Computer / PC Build
+
+- [PCPartPicker](https://pcpartpicker.com/list/) - Tool for planning and building custom PCs, enabling users to create part lists, compare prices, and ensure compatibility between components.
+- [PCBuilder](https://pcbuilder.net/list/) - Platform for designing custom PC builds, providing component compatibility checks, price comparisons, and configuration options for users.
+- [PC Builds](https://pc-builds.com/) - Resource for custom PC builds, offering curated lists of compatible components, guides, and recommendations for various performance levels and budgets.
+- [LinearMouse](https://linearmouse.app/) - Utility for Mac that provides advanced mouse and trackpad customization options, allowing users to fine-tune gestures, button mappings, and scrolling behavior.
+
+### Keyboard
+
+- [MechanicalKeyboards](https://mechanicalkeyboards.com/index.php) - Largest dedicated catalog of mechanical keyboards worldwide, offering fast shipping and after-sale support.
+- [Keycaps.info](https://www.keycaps.info/) - Resource for keycap enthusiasts, providing information on various keycap profiles, designs, and compatibility for mechanical keyboards.
+- [Keybr](https://www.keybr.com/) - Website offering a platform for improving touch typing skills with customizable lessons.
+- [PairType](https://www.pairtype.com/) - Online tool for practicing touch typing with a partner in real-time.
+- [KeyCombiner](https://keycombiner.com/) - Platform for learning and practicing keyboard shortcuts and key combinations.
+- [Yip-Yip](https://www.yip-yip.com/) - Online tool providing keyboard shortcuts for various applications and programs.
+- [Keebmaker](https://keebmaker.com/) - Resource for creating custom mechanical keyboards.
+- [Colemak - Learn](https://colemak.com/Learn) - Learning resources for the Colemak keyboard layout.
+
+#### Typing Practice
+
+- [TypeFast](https://typefast.io/) - A typing practice platform designed to help users improve their typing speed and accuracy through engaging challenges and exercises.
+- [10FastFingers](https://10fastfingers.com/typing-test/english) - Typing test platform to measure typing speed and accuracy in English.
+- [TypingClub](https://www.typingclub.com/) - Platform providing interactive typing lessons and games to improve typing skills.
+- [Typing.com](https://www.typing.com/) - Online resource offering typing lessons, games, and tests for learners of all levels.
+
+#### Keyboard Shortcuts
+
+- [UseTheKeyboard](https://usethekeyboard.com/) - Collection of keyboard shortcuts for Mac apps, Windows programs, and websites, covering a wide range of common applications.
+- [ASCII Tables](https://ascii-tables.com/) - Online resource providing an ASCII table, ALT codes, Z Score table, Greek Alphabet, T Distribution table, and a Binary Translator.
+- [ShortcutFoo](https://www.shortcutfoo.com/) - Platform for practicing keyboard shortcuts for free, supporting Mac, Windows, Linux, and offering cheat sheets for various applications, languages, and terminals.
+- [Microsoft Word Keyboard Shortcuts](https://support.microsoft.com/en-us/office/keyboard-shortcuts-in-word-95ef89dd-7142-4b50-afb2-f762f663ceb2) - Official Microsoft Office support page providing a comprehensive list of keyboard shortcuts for Microsoft Word.
+
+## Other Websites of Websites
+
+- [Stumbled.to](https://stumbled.to/) - Platform for discovering and sharing interesting websites and content.
+- [5000Best](https://5000best.com/websites/) - Curated collection of the 5000 best websites across various categories.
+- [Neal.fun](https://neal.fun/) - Website featuring entertaining and interactive projects.
+- [Tennessine](https://tennessine.co.uk/) - Collection of political, mathematical, and fun projects for the web.
+- [Blakeir](https://blakeir.com/blog/smart-youtube) - Blog post listing some YouTube pages with smart and insightful content.
+- [AwesomeOSINT on GitHub](https://awesomeopensource.com/project/jivoi/awesome-osint#-pastebins) - GitHub repository containing a curated list of open-source intelligence tools and resources.
+- [MadeWithBubble](https://www.madewithbubble.xyz/) - Platform to discover apps and websites created using the Bubble development platform.
+- [NoviceDock](https://novicedock.com/) - Platform offering curated resources for learning programming and related topics.
+- [Hackr.io](https://hackr.io/) - Platform to find programming courses and tutorials recommended by the programming community.
+- [Limnology](https://limnology.co/en) - Curation of educational YouTube channels in 20 different languages, categorized by topic, with the option to find similar channels.
+- [Tech Blogs](https://tech-blogs.dev/) - List of Awesome Tech Blogs.
+- [Track Awesome List](https://www.trackawesomelist.com/) - Track over 500 awesome list updates, and you can also subscribe to daily or weekly updates via RSS or News Letter.
+- [Internet Is Fun](https://projects.kwon.nyc/internet-is-fun/) - Collection of fun and interesting websites on the internet.
+- [Wiby](https://wiby.me/) - Search engine for the classic web, aiming to recreate the browsing experience of earlier days of the internet, particularly suitable for vintage computers.
+
+<br>
+
+# Contributing
+
+- If you want to add a new category or website:
+  - Do not add a website if it is malicious, dangerous, illegal, etc. (you can check its security by running it through a program such as [VirusTotal](https://www.virustotal.com/gui/home)).
+  - Do not add a website if it is merely for entertainment and not really useful for anything.
+  - To avoiding duplications, seach whether the website is already included.
+  - Create a [pull request](https://github.com/atakanaltok/awesome-useful-websites/pulls).
+
+- If you are a site owner and believe that your site is not described accurately, please [rise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).
+
+- If a website is down for some reason, it is generally kept in the list for archiving purposes, and also in case their maintainers might restore them. However, if the destination of a link has changed or a link is now broken, please [rise an issue](https://github.com/atakanaltok/awesome-useful-websites/issues).
+
+<br>
+
+# DISCLAIMER
+
+By accessing and using the Awesome Useful Websites project ("the Project") on GitHub, you agree that the Project is not affiliated with, sponsored by, or endorsed by any of the websites listed. While efforts are made to maintain accurate and up-to-date information, the Project makes no guarantees regarding the accuracy, completeness, or reliability of the content. Changes of the content of linked websites are beyond the Project's control. Users access linked websites at their own risk and discretion. The Project is provided "as is" without any warranties, express or implied.
+
+<br>
+
+# LICENSE
+
+<div align="center">
+
+[<img src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by.png"
+alt="Creative Commons Attribution 4.0 International"
+height="40">](http://creativecommons.org/licenses/by/4.0/)
+
+</div>
+
+This work is licensed under a [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).
+
+**How to credit:**
+
+- You must add a link to this [GitHub main page](https://github.com/atakanaltok/awesome-useful-websites) in an `about` or `acknowledgments` section visible to the user.


### PR DESCRIPTION
This PR adds AIPower.spot, an online catalog and platform for searching and selecting tools based on artificial intelligence (AI).