### PR TITLE
docs: add iambored.site to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2112,6 +2112,7 @@ Each website is included only once. Some websites can fall into multiple categor
 - [Track Awesome List](https://www.trackawesomelist.com/) - Track over 500 awesome list updates, and you can also subscribe to daily or weekly updates via RSS or News Letter.
 - [Internet Is Fun](https://projects.kwon.nyc/internet-is-fun/) - Collection of fun and interesting websites on the internet.
 - [Wiby](https://wiby.me/) - Search engine for the classic web, aiming to recreate the browsing experience of earlier days of the internet, particularly suitable for vintage computers.
+- [iambored.site](https://iambored.site/) - An interactive web platform designed to help users break out of boredom by teleporting them to a random, curated website.
 
 <br>
 


### PR DESCRIPTION
This PR adds iambored.site to the list of cool, useless, or fun websites. It is described as: an interactive web platform designed to help users break out of boredom by teleporting them to a random, curated website.